### PR TITLE
Replace System.Drawing with ImageSharp for Cross-Platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ livenessdb
 *.userosscache
 *.sln.docstates
 *.local.json
+.vscode
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/BotDeScans.App/BotDeScans.App.csproj
+++ b/BotDeScans.App/BotDeScans.App.csproj
@@ -54,6 +54,7 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
     <PackageReference Include="StringToExpression" Version="2.2.0" />
     <PackageReference Include="System.Drawing.Common" Version="9.0.1" />
     <PackageReference Include="System.Text.Json" Version="9.0.1" />

--- a/BotDeScans.App/Services/ImageService.cs
+++ b/BotDeScans.App/Services/ImageService.cs
@@ -1,9 +1,9 @@
 ﻿using Imageflow.Fluent;
 using Microsoft.Extensions.Configuration;
-using System.Drawing;
-using System.Drawing.Imaging;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.PixelFormats;
 using System.Runtime.InteropServices;
-using PixelFormat = System.Drawing.Imaging.PixelFormat;
 namespace BotDeScans.App.Services;
 
 public class ImageService(IConfiguration configuration)
@@ -72,72 +72,47 @@ public class ImageService(IConfiguration configuration)
     }
 
     private (int quality, int minQuality) GetImageQuality(string filePath)
-    {
-        using var bitmap = new Bitmap(filePath);
-        return GetImageQuality(bitmap);
-    }
-
-    private (int quality, int minQuality) GetImageQuality(Bitmap bitmap)
-        => IsGrayscale(bitmap, 10)
+        => IsGrayscale(filePath, 10)
             ? (configuration.GetValue<int?>("Compress:Grayscale:Quality") ?? 50,
                configuration.GetValue<int?>("Compress:Grayscale:MinimumQuality") ?? 30)
             : (configuration.GetValue<int?>("Compress:Colorful:Quality") ?? 90,
                configuration.GetValue<int?>("Compress:Colorful:MinimumQuality") ?? 85);
 
     /// <summary>
-    /// Source: https://stackoverflow.com/a/1877420
+    /// Source: https://stackoverflow.com/a/62961179
+    /// Determine if an image is greyscale
     /// </summary>
-    /// <param name="bitmap"></param>
+    /// <param name="filePath">The path to the image file.</param>
     /// <param name="threshold"></param>
     /// <returns></returns>
-    private static bool IsGrayscale(Bitmap bitmap, int threshold)
+    private static bool IsGrayscale(string filePath, int threshold)
     {
-        // Indexed format, and no non-gray colours in the images palette: immediate pass.
-        if ((bitmap.PixelFormat & PixelFormat.Indexed) == PixelFormat.Indexed
-            && bitmap.Palette.Entries.All(c => c.R == c.G && c.R == c.B))
-            return true;
-
-        // Quick indexed check failed; actually check image data.
-        // Get bytes out of the image, converted to 32bpp ARGB 
-        var curBitmapData = bitmap.LockBits(
-            new Rectangle(0, 0, bitmap.Width, bitmap.Height),
-            ImageLockMode.ReadOnly,
-            PixelFormat.Format32bppArgb);
-
-        var stride = curBitmapData.Stride;
-        var data = new byte[stride * bitmap.Height];
-        Marshal.Copy(curBitmapData.Scan0, data, 0, data.Length);
-        bitmap.UnlockBits(curBitmapData);
-        // Go over all bytes per block of four.
-        var curRowOffs = 0;
-        for (var y = 0; y < bitmap.Height; y++)
+        //Load image
+        var image = Image.Load<Rgba32>(filePath);
+        for (int y = 0; y < image.Height; y++)
         {
-            // Set offset to start of current row
-            var curOffs = curRowOffs;
-            for (var x = 0; x < bitmap.Width; x++)
+            // Get the row of pixels
+            Memory<Rgba32> row = image.DangerousGetPixelRowMemory(y);
+            Span<Rgba32> data = row.Span;
+
+            for (int x = 0; x < image.Width; x++)
             {
-                var b = data[curOffs];
-                var g = data[curOffs + 1];
-                var r = data[curOffs + 2];
-                var a = data[curOffs + 3];
+                var pixel = data[x];
 
-                // Increase offset to next colour
-                curOffs += 4;
-
-                if (a == 0)
+                if (pixel.A == 0)
                     continue;
-                if (GetRgbDelta(r, g, b) > threshold)
+
+                if (GetRgbDelta(pixel.R, pixel.G, pixel.B) > threshold)
                     return false;
             }
-            // Increase row offset
-            curRowOffs += stride;
         }
+
+        return true;
 
         static int GetRgbDelta(byte r, byte g, byte b)
             => Math.Abs(r - g) +
                Math.Abs(g - b) +
                Math.Abs(b - r);
 
-        return true;
     }
 }


### PR DESCRIPTION
## Changes applied
This PR replaces the usage of `System.Drawing (GDI+)` with `SixLabors.ImageSharp` in the IsGrayscale method.
The main motivation behind this change is to ensure cross-platform compatibility, as System.Drawing is tightly coupled with Windows and does not work natively on Linux/macOS without additional dependencies.