### PR TITLE
Receives ids instead title names from discord parameters

### DIFF
--- a/BotDeScans.App/BotDeScans.App.csproj
+++ b/BotDeScans.App/BotDeScans.App.csproj
@@ -49,7 +49,6 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
     <PackageReference Include="Remora.Discord" Version="2024.3.0" />
     <PackageReference Include="ScottPlot" Version="5.0.55" />
-    <PackageReference Include="Scrutor" Version="6.0.1" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />

--- a/BotDeScans.App/Features/Publish/Discord/PublishCommands.cs
+++ b/BotDeScans.App/Features/Publish/Discord/PublishCommands.cs
@@ -14,7 +14,6 @@ namespace BotDeScans.App.Features.Publish.Discord;
 
 public class PublishCommands(
     IOperationContext context,
-    PublishQueries publishQueries,
     IDiscordRestInteractionAPI interactionAPI) : CommandGroup
 {
     [Command("publish")]
@@ -24,19 +23,18 @@ public class PublishCommands(
     public async Task<IResult> PublishAsync(
         [AutocompleteProvider(AutocompleteTitles.Id)]
         [Description("Nome da obra")]
-        string title)
+        int title)
     {
         if (context is not InteractionContext interactionContext)
             return Result.FromSuccess();
 
-        var titleId = await publishQueries.GetTitleIdAsync(title, CancellationToken);
         var modal = new ModalBuilder(nameof(PublishInteractions.PublishAsync), "Publicar novo lançamento")
             .AddField(fieldName: "driveUrl", label: "Link do capítulo")
             .AddField(fieldName: "chapterName", label: "Nome do capítulo", isRequired: false)
             .AddField(fieldName: "chapterNumber", label: "Número do capítulo")
             .AddField(fieldName: "chapterVolume", label: "Número do Volume", isRequired: false)
             .AddField(fieldName: "message", label: "Mensagem de postagem", isRequired: false, TextInputStyle.Paragraph)
-            .CreateWithState(titleId.ToString());
+            .CreateWithState(title.ToString());
 
         return await interactionAPI.CreateInteractionResponseAsync
         (

--- a/BotDeScans.App/Features/Publish/PublishQueries.cs
+++ b/BotDeScans.App/Features/Publish/PublishQueries.cs
@@ -9,10 +9,4 @@ public class PublishQueries(DatabaseContext databaseContext)
         => databaseContext.Titles
             .Include(x => x.References)
             .SingleAsync(x => x.Id == id, cancellationToken);
-
-    public virtual Task<int> GetTitleIdAsync(string name, CancellationToken cancellationToken) =>
-        databaseContext.Titles
-            .Where(x => x.Name == name)
-            .Select(x => x.Id)
-            .SingleAsync(cancellationToken);
 }

--- a/BotDeScans.App/Features/References/List/Commands.cs
+++ b/BotDeScans.App/Features/References/List/Commands.cs
@@ -21,9 +21,9 @@ public class Commands(
     public async Task<IResult> ListAsync(
         [AutocompleteProvider(AutocompleteTitles.Id)]
         [Description("Nome da obra")]
-        string titleName)
+        int title)
     {
-        var result = await handler.ExecuteAsync(titleName, CancellationToken);
+        var result = await handler.ExecuteAsync(title, CancellationToken);
         var embed = EmbedBuilder.CreateSuccessEmbed(string.Join(Environment.NewLine, result));
 
         return await feedbackService.SendContextualEmbedAsync(embed, ct: CancellationToken);

--- a/BotDeScans.App/Features/References/List/Handler.cs
+++ b/BotDeScans.App/Features/References/List/Handler.cs
@@ -2,9 +2,9 @@
 
 public class Handler(Persistence persistence)
 {
-    public async Task<string[]> ExecuteAsync(string titleName, CancellationToken cancellationToken)
+    public async Task<string[]> ExecuteAsync(int titleId, CancellationToken cancellationToken)
     {
-        var references = await persistence.GetReferencesAsync(titleName, cancellationToken);
+        var references = await persistence.GetReferencesAsync(titleId, cancellationToken);
 
         return references.Count == 0
             ? ["A obra não contém referências."]

--- a/BotDeScans.App/Features/References/List/Persistence.cs
+++ b/BotDeScans.App/Features/References/List/Persistence.cs
@@ -8,10 +8,10 @@ public class Persistence(DatabaseContext context)
 {
     private readonly DatabaseContext context = context;
 
-    public virtual Task<List<TitleReference>> GetReferencesAsync(string titleName, CancellationToken cancellationToken) =>
+    public virtual Task<List<TitleReference>> GetReferencesAsync(int titleId, CancellationToken cancellationToken) =>
         context.Titles
-            .Where(x => x.Name == titleName)
             .Include(x => x.References)
+            .Where(x => x.Id == titleId)
             .SelectMany(x => x.References)
             .ToListAsync(cancellationToken);
 }

--- a/BotDeScans.App/Features/References/Update/Commands.cs
+++ b/BotDeScans.App/Features/References/Update/Commands.cs
@@ -22,7 +22,7 @@ public class Commands(
     public async Task<IResult> UpdateAsync(
         [AutocompleteProvider(AutocompleteTitles.Id)]
         [Description("Nome da obra")]
-        string title,
+        int title,
         [Description("Nome da referência")]
         ExternalReference reference,
         [Description("Valor da referência")]

--- a/BotDeScans.App/Features/References/Update/Handler.cs
+++ b/BotDeScans.App/Features/References/Update/Handler.cs
@@ -14,7 +14,7 @@ public class Handler(
         if (validationResult.IsValid is false)
             return validationResult.ToResult();
 
-        var title = await persistence.GetTitleAsync(request.Title, cancellationToken);
+        var title = await persistence.GetTitleAsync(request.TitleId, cancellationToken);
 
         title.AddOrUpdateReference(request.ReferenceKey, request.ReferenceValue);
 

--- a/BotDeScans.App/Features/References/Update/Persistence.cs
+++ b/BotDeScans.App/Features/References/Update/Persistence.cs
@@ -8,9 +8,9 @@ public class Persistence(DatabaseContext context) : SaveChanges(context)
 {
     private readonly DatabaseContext context = context;
 
-    public virtual Task<Title> GetTitleAsync(string name, CancellationToken cancellationToken) =>
+    public virtual Task<Title> GetTitleAsync(int id, CancellationToken cancellationToken) =>
         context.Titles
             .Include(x => x.References)
-            .Where(x => x.Name == name)
+            .Where(x => x.Id == id)
             .SingleAsync(cancellationToken);
 }

--- a/BotDeScans.App/Features/References/Update/Request.cs
+++ b/BotDeScans.App/Features/References/Update/Request.cs
@@ -3,7 +3,7 @@ using FluentValidation;
 
 namespace BotDeScans.App.Features.References.Update;
 
-public record Request(string Title, ExternalReference ReferenceKey, string ReferenceRawValue)
+public record Request(int TitleId, ExternalReference ReferenceKey, string ReferenceRawValue)
 {
     public const int GUID_CHAR_LENGHT = 36;
     public const string MANGADEX_ID_URL_PREFIX = "/title/";
@@ -22,7 +22,7 @@ public class RequestValidator : AbstractValidator<Request>
 {
     public RequestValidator()
     {
-        RuleFor(request => request.Title).NotEmpty();
+        RuleFor(request => request.TitleId).NotEmpty();
 
         RuleFor(request => request.ReferenceKey).IsInEnum();
 

--- a/BotDeScans.App/Features/Titles/TitleCommands.cs
+++ b/BotDeScans.App/Features/Titles/TitleCommands.cs
@@ -77,12 +77,12 @@ public class TitleCommands(
     public async Task<IResult> Update(
         [AutocompleteProvider(AutocompleteTitles.Id)]
         [Description("Nome da obra")]
-        string titleName)
+        int titleId)
     {
         if (context is not InteractionContext interactionContext)
             return Result.FromSuccess();
 
-        var title = await databaseContext.Titles.FirstOrDefaultAsync(x => x.Name == titleName);
+        var title = await databaseContext.Titles.FirstOrDefaultAsync(x => x.Id == titleId);
         if (title is null)
             return await feedbackService.SendContextualWarningAsync(
                 "Obra não encontrada.",

--- a/BotDeScans.App/Models/Consts.cs
+++ b/BotDeScans.App/Models/Consts.cs
@@ -1,0 +1,6 @@
+﻿namespace BotDeScans.App.Models;
+
+public static class Consts
+{
+    public const int DISCORD_PARAM_MAX_LENGTH = 100;
+}

--- a/BotDeScans.App/Services/Discord/Autocomplete/AutocompleteTitles.cs
+++ b/BotDeScans.App/Services/Discord/Autocomplete/AutocompleteTitles.cs
@@ -17,7 +17,7 @@ public class AutocompleteTitles(DatabaseContext databaseContext) : IAutocomplete
         CancellationToken ct = default)
     {
         var titles = await databaseContext.Titles
-            .Where(x => x.Name.Contains(userInput))
+            .Where(x => EF.Functions.Like(x.Name, $"%{userInput}%"))
             .Take(25)
             .ToArrayAsync(ct);
 

--- a/BotDeScans.UnitTests/Specs/Features/Publish/Discord/PublishCommandsTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/Publish/Discord/PublishCommandsTests.cs
@@ -12,25 +12,16 @@ public class PublishCommandsTests : UnitTest
 {
     public class PublishAsync : PublishCommandsTests
     {
-        private const int TEST_TITLE_ID = 123456;
-
-        private readonly string title;
+        private const int titleId = 123456;
         private readonly PublishCommands commands;
 
         public PublishAsync()
         {
-            title = fixture.Create<string>();
-
             fixture.FreezeFake<PublishQueries>();
             fixture.FreezeFake<IDiscordRestInteractionAPI>();
             fixture.Inject<IOperationContext>(new FakeInteractionContext(fixture));
 
             commands = fixture.CreateCommand<PublishCommands>(cancellationToken);
-
-            A.CallTo(() => fixture
-                .FreezeFake<PublishQueries>()
-                .GetTitleIdAsync(title, cancellationToken))
-                .Returns(TEST_TITLE_ID);
 
             A.CallTo(() => fixture
                 .FreezeFake<IDiscordRestInteractionAPI>()
@@ -46,7 +37,7 @@ public class PublishCommandsTests : UnitTest
         [Fact]
         public async Task GivenSuccessExecutionShouldReturnSuccess()
         {
-            var result = await commands.PublishAsync(title);
+            var result = await commands.PublishAsync(titleId);
 
             result.IsSuccess.Should().BeTrue();
         }
@@ -54,7 +45,7 @@ public class PublishCommandsTests : UnitTest
         [Fact]
         public async Task GivenSuccessExecutionShouldReturnExpectedObjectInMessage()
         {
-            await commands.PublishAsync(title);
+            await commands.PublishAsync(titleId);
 
             var modalData = Fake.GetCalls(fixture
                 .FreezeFake<IDiscordRestInteractionAPI>())
@@ -69,7 +60,7 @@ public class PublishCommandsTests : UnitTest
             fixture.Inject(A.Fake<IOperationContext>());
             var commands = fixture.CreateCommand<PublishCommands>(cancellationToken);
 
-            var result = await commands.PublishAsync(title);
+            var result = await commands.PublishAsync(titleId);
 
             result.IsSuccess.Should().BeTrue();
 
@@ -91,7 +82,7 @@ public class PublishCommandsTests : UnitTest
                     cancellationToken))
                 .Returns(new InvalidOperationError());
 
-            var result = await commands.PublishAsync(title);
+            var result = await commands.PublishAsync(titleId);
 
             result.IsSuccess.Should().BeFalse();
         }

--- a/BotDeScans.UnitTests/Specs/Features/Publish/PublishQueriesTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/Publish/PublishQueriesTests.cs
@@ -39,22 +39,4 @@ public class PublishQueriesTests : UnitPersistenceTest, IDisposable
             result.Should().BeEquivalentTo(expectedResult);
         }
     }
-
-    public class GetTitleIdAsync : PublishQueriesTests
-    {
-        [Fact]
-        public async Task GivenExpectedNameShouldReturnTitleId()
-        {
-            var expectedTitle = fixture.Build<Title>().With(x => x.Id, 1).With(x => x.References, []).Create();
-            var unexpectedTitle = fixture.Build<Title>().With(x => x.Id, 2).With(x => x.References, []).Create();
-
-            await fixture.Freeze<DatabaseContext>().AddAsync(expectedTitle, cancellationToken);
-            await fixture.Freeze<DatabaseContext>().AddAsync(unexpectedTitle, cancellationToken);
-            await fixture.Freeze<DatabaseContext>().SaveChangesAsync(cancellationToken);
-
-            var result = await queries.GetTitleIdAsync(expectedTitle.Name, cancellationToken);
-
-            result.Should().Be(expectedTitle.Id);
-        }
-    }
 }

--- a/BotDeScans.UnitTests/Specs/Features/References/List/HandlerTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/References/List/HandlerTests.cs
@@ -16,15 +16,15 @@ public class HandlerTests : UnitTest
 
     public class ExecuteAsync : HandlerTests
     {
-        private readonly string titleName;
+        private readonly int titleId;
 
         public ExecuteAsync()
         {
-            titleName = fixture.Create<string>();
+            titleId = fixture.Create<int>();
 
             A.CallTo(() => fixture
                 .FreezeFake<Persistence>()
-                .GetReferencesAsync(titleName, cancellationToken))
+                .GetReferencesAsync(titleId, cancellationToken))
                 .Returns(
                 [
                     new() { Key = ExternalReference.MangaDex, Value = "manga-dex-value" },
@@ -35,7 +35,7 @@ public class HandlerTests : UnitTest
         [Fact]
         public async Task GivenReferencesFoundShouldReturnExpectedStringList()
         {
-            var result = await handler.ExecuteAsync(titleName, cancellationToken);
+            var result = await handler.ExecuteAsync(titleId, cancellationToken);
 
             var expectedStrings = new[]
             {
@@ -51,10 +51,10 @@ public class HandlerTests : UnitTest
         {
             A.CallTo(() => fixture
                 .FreezeFake<Persistence>()
-                .GetReferencesAsync(titleName, cancellationToken))
+                .GetReferencesAsync(titleId, cancellationToken))
                 .Returns([]);
 
-            var result = await handler.ExecuteAsync(titleName, cancellationToken);
+            var result = await handler.ExecuteAsync(titleId, cancellationToken);
 
             var expectedStrings = new[] { "A obra não contém referências." };
 

--- a/BotDeScans.UnitTests/Specs/Features/References/List/PersistenceTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/References/List/PersistenceTests.cs
@@ -29,7 +29,7 @@ public class PersistenceTests : UnitPersistenceTest
             await fixture.Freeze<DatabaseContext>().AddAsync(unexpectedReference, cancellationToken);
             await fixture.Freeze<DatabaseContext>().SaveChangesAsync(cancellationToken);
 
-            var result = await persistence.GetReferencesAsync(expectedTitle.Name, cancellationToken);
+            var result = await persistence.GetReferencesAsync(expectedTitle.Id, cancellationToken);
 
             result.Should().BeEquivalentTo(expectedResult);
         }

--- a/BotDeScans.UnitTests/Specs/Features/References/Update/HandlerTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/References/Update/HandlerTests.cs
@@ -38,7 +38,7 @@ public class HandlerTests : UnitTest
 
             A.CallTo(() => fixture
                 .FreezeFake<Persistence>()
-                .GetTitleAsync(request.Title, cancellationToken))
+                .GetTitleAsync(request.TitleId, cancellationToken))
                 .Returns(title);
         }
 

--- a/BotDeScans.UnitTests/Specs/Features/References/Update/PersistenceTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/References/Update/PersistenceTests.cs
@@ -34,7 +34,7 @@ public class PersistenceTests : UnitPersistenceTest
             await fixture.Freeze<DatabaseContext>().AddAsync(unexpectedReference, cancellationToken);
             await fixture.Freeze<DatabaseContext>().SaveChangesAsync(cancellationToken);
 
-            var result = await persistence.GetTitleAsync(expectedTitle.Name, cancellationToken);
+            var result = await persistence.GetTitleAsync(expectedTitle.Id, cancellationToken);
 
             result.Should().BeEquivalentTo(expectedResult);
         }

--- a/BotDeScans.UnitTests/Specs/Features/References/Update/RequestValidatorTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/References/Update/RequestValidatorTests.cs
@@ -6,7 +6,7 @@ namespace BotDeScans.UnitTests.Specs.Features.References.Update;
 
 public class RequestValidatorTests : UnitTest
 {
-    private static readonly Request request = new("random-title", ExternalReference.MangaDex, Guid.NewGuid().ToString());
+    private static readonly Request request = new(9, ExternalReference.MangaDex, Guid.NewGuid().ToString());
 
     [Fact]
     public void GivenValidDataShouldNotHaveValidationErrors() =>
@@ -14,14 +14,11 @@ public class RequestValidatorTests : UnitTest
                .TestValidate(request)
                .ShouldNotHaveAnyValidationErrors();
 
-    [Theory]
-    [InlineData("")]
-    [InlineData(" ")]
-    [InlineData(null)]
-    public void GivenEmptyTitleShouldHaveValidationErrors(string? title) =>
+    [Fact]
+    public void GivenEmptyTitleIdShouldHaveValidationErrors() =>
         fixture.Create<RequestValidator>()
-               .TestValidate(request with { Title = title! })
-               .ShouldHaveValidationErrorFor(x => x.Title)
+               .TestValidate(request with { TitleId = default })
+               .ShouldHaveValidationErrorFor(x => x.TitleId)
                .Only();
 
     [Theory]


### PR DESCRIPTION
This pull request refactors the codebase to replace title names with title IDs as the primary identifier for operations across several features. Additionally, it introduces a new constant for Discord parameter length and optimizes the autocomplete functionality. The changes improve consistency, performance, and maintainability.

### Refactoring to use title IDs instead of title names:

* **Publish Commands**: Updated `PublishCommands` to use title IDs instead of names, removing dependency on `PublishQueries.GetTitleIdAsync`. Adjusted the modal creation logic accordingly. (`BotDeScans.App/Features/Publish/Discord/PublishCommands.cs`, [BotDeScans.App/Features/Publish/Discord/PublishCommands.csL27-R37](diffhunk://#diff-84a96dc955019f27fa9420925adf5e637953763e2c33017347f5de0e3abf3a1aL27-R37))
* **References List**: Modified `Commands`, `Handler`, and `Persistence` classes to use title IDs for fetching references. (`BotDeScans.App/Features/References/List/Commands.cs`, [[1]](diffhunk://#diff-6e97761eca60d2804f23968c1292fe8cbc2b20e1e5e86223f9ca233357603d2eL24-R26); `BotDeScans.App/Features/References/List/Handler.cs`, [[2]](diffhunk://#diff-f2e4155c3b889b89e0ddc9a0068f00ac133b9234b032877aaeb9fdd50cadf4d4L5-R7); `BotDeScans.App/Features/References/List/Persistence.cs`, [[3]](diffhunk://#diff-2c8d1261cf49ef378e1785a7d2f58686a39e031da25ab75ea26a5ab8b37a15f1L11-R14)
* **References Update**: Adjusted `Commands`, `Handler`, `Persistence`, and `Request` classes to use title IDs for updating references. (`BotDeScans.App/Features/References/Update/Commands.cs`, [[1]](diffhunk://#diff-11d999780744a782554c58c2bb643ef3a09e562bc107225bcbb389bce2e71871L25-R25); `BotDeScans.App/Features/References/Update/Handler.cs`, [[2]](diffhunk://#diff-714d0030cc6daeec8d6489f630f9968017586ffaa62e6b1fbd0f086fb92b8070L17-R17); `BotDeScans.App/Features/References/Update/Persistence.cs`, [[3]](diffhunk://#diff-2379999f101ff7eba093441e43089149389ea9409881744008329258dfe500f1L11-R14); `BotDeScans.App/Features/References/Update/Request.cs`, [[4]](diffhunk://#diff-7e9631252fa07c281652410c0a6fad396d318bb3854608f26deb7bdb32842317L6-R6)
* **Titles Update**: Updated `TitleCommands` to use title IDs for title-related operations. (`BotDeScans.App/Features/Titles/TitleCommands.cs`, [BotDeScans.App/Features/Titles/TitleCommands.csL80-R85](diffhunk://#diff-c2304071b8046233b8562120cee7a28c308b47e8fad4fd9123abb9188664984eL80-R85))

### Removal of redundant methods:

* **PublishQueries**: Removed `GetTitleIdAsync` method, as title names are no longer used for identification. (`BotDeScans.App/Features/Publish/PublishQueries.cs`, [BotDeScans.App/Features/Publish/PublishQueries.csL12-L17](diffhunk://#diff-aac0d655c94742d9b14b49eb1c9cc0612b4bcf14455decfd98b86a405848e378L12-L17))

### Optimization and new constants:

* **Autocomplete**: Improved `AutocompleteTitles` to filter titles by user input and limit results to 25, using title IDs for value assignment. Introduced `Consts.DISCORD_PARAM_MAX_LENGTH` for truncating long names. (`BotDeScans.App/Services/Discord/Autocomplete/AutocompleteTitles.cs`, [[1]](diffhunk://#diff-6466ea59c4e97d868726d155ea5479f4a06554346dd22827f352aa5c65615712L19-R29); `BotDeScans.App/Models/Consts.cs`, [[2]](diffhunk://#diff-29c703c7bedecc4dba8aee8c434576efd4d82643176d7c44b66129c08329f57bR1-R6)

### Unit test updates:

* **PublishCommandsTests**: Adjusted tests to use title IDs instead of names, removing mock calls to `GetTitleIdAsync`. (`BotDeScans.UnitTests/Specs/Features/Publish/Discord/PublishCommandsTests.cs`, [BotDeScans.UnitTests/Specs/Features/Publish/Discord/PublishCommandsTests.csL15-L34](diffhunk://#diff-8e3e1c74c92c905bba0c583d1785f35db197c7f2c088c47c7525b1de4e459b99L15-L34))
* **References List Tests**: Updated tests for `Handler` and `Persistence` to reflect changes in identifier usage. (`BotDeScans.UnitTests/Specs/Features/References/List/HandlerTests.cs`, [[1]](diffhunk://#diff-dfda91b2937aea44ecdf144cacd521a5aa5a88b46957d626925210b51a7b6ffdL19-R27); `BotDeScans.UnitTests/Specs/Features/References/List/PersistenceTests.cs`, [[2]](diffhunk://#diff-1b8a3d4cd859503dbe67fd5bd3c6c2dcdfa4245f375d48fb315b777aeb6446d2L32-R32)
* **References Update Tests**: Modified tests for `Handler` and `Persistence` to use title IDs. (`BotDeScans.UnitTests/Specs/Features/References/Update/HandlerTests.cs`, [[1]](diffhunk://#diff-781beb53f7669f8800ab36b971a74f528b6e7e6183089bd87aec133607e55796L41-R41); `BotDeScans.UnitTests/Specs/Features/References/Update/PersistenceTests.cs`, [[2]](diffhunk://#diff-b0701e563133119af02216e87a2cfcb17688eabc9cc50dbd7a84c15afa216194L37-R37)