### PR TITLE
Add cover size validatior

### DIFF
--- a/BotDeScans.App/Features/GoogleDrive/FileListValidator.cs
+++ b/BotDeScans.App/Features/GoogleDrive/FileListValidator.cs
@@ -19,6 +19,10 @@ public class FileListValidator : AbstractValidator<IList<File>>
             .WithMessage("O diretório precisa conter apenas uma única página de capa. (ex: capa.extensão)");
 
         RuleFor(model => model)
+            .Must(ShouldExpectedSizeCoverFile)
+            .WithMessage("A página de capa precisa ser uma imagem válida menor que 8Mb.");
+
+        RuleFor(model => model)
             .Must(ShouldHaveExactlyOneCreditsFile)
             .WithMessage("O diretório precisa conter apenas uma única página de créditos. (ex: creditos.extensão)");
 
@@ -54,6 +58,12 @@ public class FileListValidator : AbstractValidator<IList<File>>
         files.Where(x => x.Kind == "drive#file")
              .Count(x => FileReleaseService.ValidCoverFiles.Contains(x.Name, StringComparer.InvariantCulture))
               == 1;
+
+    private static bool ShouldExpectedSizeCoverFile(IList<File> files) =>
+        files.Where(x => x.Kind == "drive#file")
+             .Where(x => FileReleaseService.ValidCoverFiles.Contains(x.Name, StringComparer.InvariantCulture))
+             .All(x => x.Size is not null 
+                    && x.Size <= 8 * 1024 * 1024);
 
     private static bool ShouldHaveExactlyOneCreditsFile(IList<File> files) =>
         files.Where(x => x.Kind == "drive#file")

--- a/BotDeScans.App/Features/GoogleDrive/InternalServices/GoogleDriveResourcesService.cs
+++ b/BotDeScans.App/Features/GoogleDrive/InternalServices/GoogleDriveResourcesService.cs
@@ -35,6 +35,8 @@ public class GoogleDriveResourcesService(
 
         var listRequest = driveService.Files.List();
         listRequest.Q = query;
+        listRequest.PageSize = 1000;
+        listRequest.Fields = "files(*)";
         var requestResult = await googleWrapper.ExecuteAsync(listRequest, cancellationToken);
 
         if (requestResult.IsFailed)

--- a/BotDeScans.UnitTests/Specs/Features/GoogleDrive/FileListValidatorTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/GoogleDrive/FileListValidatorTests.cs
@@ -13,7 +13,7 @@ public class FileListValidatorTests : UnitTest
         new File { Kind = "drive#file", Name = "02.png" },
         new File { Kind = "drive#file", Name = "03-04.png" },
         new File { Kind = "drive#file", Name = "05.png" },
-        new File { Kind = "drive#file", Name = "capa.png" },
+        new File { Kind = "drive#file", Name = "capa.png", Size = 8 * 1024 * 1024 },
         new File { Kind = "drive#file", Name = "creditos.png" }
     ];
 
@@ -37,6 +37,24 @@ public class FileListValidatorTests : UnitTest
         validator.TestValidate(data)
             .ShouldHaveAnyValidationError()
             .WithErrorMessage("O diretório precisa conter apenas uma única página de capa. (ex: capa.extensão)");
+    }
+
+    [Fact]
+    public void ShouldBeInvalidIfCoverFileIsAnEmptyFile()
+    {
+        data[4].Size = null;
+        validator.TestValidate(data)
+            .ShouldHaveAnyValidationError()
+            .WithErrorMessage("A página de capa precisa ser uma imagem válida menor que 8Mb.");
+    }
+
+    [Fact]
+    public void ShouldBeInvalidIfCoverFileLargerThan8Mb()
+    {
+        data[4].Size = (8 * 1024 * 1024) + 1;
+        validator.TestValidate(data)
+            .ShouldHaveAnyValidationError()
+            .WithErrorMessage("A página de capa precisa ser uma imagem válida menor que 8Mb.");
     }
 
     [Fact]


### PR DESCRIPTION
This pull request improves the validation logic for Google Drive file uploads by adding stricter checks for the cover file, ensuring it is present, valid, and within size limits. It also updates the Google Drive resource service to retrieve more complete file data and enhances unit tests to cover the new validation scenarios.

**Validation improvements for cover file:**

* Added a new validation rule in `FileListValidator` to ensure the cover file is a valid image and smaller than 8Mb.
* Implemented the `ShouldExpectedSizeCoverFile` method to check that the cover file's size is set and does not exceed 8Mb.

**Google Drive resource service updates:**

* Set `PageSize` to 1000 and requested all file fields in `GoogleDriveResourcesService` to ensure complete file metadata is available for validation.

**Unit test enhancements:**

* Updated the test data in `FileListValidatorTests` to include a cover file with a size exactly at the 8Mb limit.
* Added new unit tests to check for invalid cases where the cover file is missing a size or exceeds the 8Mb limit.