### PR TITLE
Add missing Lists and References.Update.Request.ReferenceValue tests

### DIFF
--- a/BotDeScans.App/Features/References/Update/Request.cs
+++ b/BotDeScans.App/Features/References/Update/Request.cs
@@ -10,12 +10,11 @@ public record Request(int TitleId, ExternalReference ReferenceKey, string Refere
     public const string MANGADEX_ID_URL_PREFIX = "/title/";
 
     // We can use a switch here when references get more complex (non guid)
-    public string ReferenceValue =>
-        Guid.TryParse(ReferenceRawValue, out var guidResult)
-            ? guidResult.ToString()
-            : ReferenceRawValue.Substring(
-                ReferenceRawValue.IndexOf(MANGADEX_ID_URL_PREFIX) + MANGADEX_ID_URL_PREFIX.Length,
-                GUID_CHAR_LENGHT);
+    public string ReferenceValue => Guid.TryParse(ReferenceRawValue, out var guidResult)
+        ? guidResult.ToString()
+        : ReferenceRawValue.Substring(
+            ReferenceRawValue.IndexOf(MANGADEX_ID_URL_PREFIX) + MANGADEX_ID_URL_PREFIX.Length,
+            GUID_CHAR_LENGHT);
 }
 
 public class RequestValidator : AbstractValidator<Request>

--- a/BotDeScans.App/Features/Titles/List/Commands.cs
+++ b/BotDeScans.App/Features/Titles/List/Commands.cs
@@ -1,7 +1,6 @@
 ﻿using BotDeScans.App.Attributes;
 using BotDeScans.App.Builders;
-using BotDeScans.App.Infra;
-using Microsoft.EntityFrameworkCore;
+using BotDeScans.App.Infra.Repositories;
 using Remora.Commands.Attributes;
 using Remora.Commands.Groups;
 using Remora.Discord.Commands.Feedback.Services;
@@ -12,8 +11,8 @@ namespace BotDeScans.App.Features.Titles.List;
 
 [Group("title")]
 public class Commands(
-    FeedbackService feedbackService,
-    DatabaseContext databaseContext)
+    IFeedbackService feedbackService,
+    TitleRepository titleRepository)
     : CommandGroup
 {
     [Command("list")]
@@ -22,13 +21,14 @@ public class Commands(
     public async Task<IResult> List()
     {
         // todo: pagination based on titles length (characters quantity) - discord api
-        var titles = await databaseContext.Titles.ToListAsync();
+        var titles = await titleRepository.GetTitlesAsync(CancellationToken);
         if (titles.Count == 0)
             return await feedbackService.SendContextualWarningAsync(
                 "Não há obras cadastradas.",
                 ct: CancellationToken);
 
         var titlesListAsText = titles
+            .OrderBy(x => x.Name)
             .Select((x, index) => new { Number = index + 1, x.Name })
             .Select(x => string.Format("{0}. {1}", x.Number, x.Name));
 

--- a/BotDeScans.App/Infra/Repositories/TitleRepository.cs
+++ b/BotDeScans.App/Infra/Repositories/TitleRepository.cs
@@ -7,9 +7,15 @@ public class TitleRepository(DatabaseContext context) : SaveChanges(context)
 {
     private readonly DatabaseContext context = context;
 
-    public virtual Task<Title?> GetTitleAsync(int titleId, CancellationToken cancellationToken) => 
+    public virtual Task<Title?> GetTitleAsync(int titleId, CancellationToken cancellationToken) =>
         context.Titles
                .Include(x => x.References)
                .Include(x => x.SkipSteps)
                .FirstOrDefaultAsync(x => x.Id == titleId, cancellationToken);
+
+    public virtual Task<List<Title>> GetTitlesAsync(CancellationToken cancellationToken) =>
+        context.Titles
+               .Include(x => x.References)
+               .Include(x => x.SkipSteps)
+               .ToListAsync(cancellationToken);
 }

--- a/BotDeScans.UnitTests/Snapshots/Features.References.List.ExecuteAsync.GivenErrorRequestShouldReturnExpectedEmbed.verified.txt
+++ b/BotDeScans.UnitTests/Snapshots/Features.References.List.ExecuteAsync.GivenErrorRequestShouldReturnExpectedEmbed.verified.txt
@@ -1,0 +1,19 @@
+﻿{
+  Title: {
+    Value: :no_entry: Erro!,
+    HasValue: true
+  },
+  Colour: {
+    Value: Red,
+    HasValue: true
+  },
+  Fields: {
+    Value: [
+      {
+        Name: Erro 1,
+        Value: some error
+      }
+    ],
+    HasValue: true
+  }
+}

--- a/BotDeScans.UnitTests/Snapshots/Features.Titles.List.CommandsTests.GivenSuccessExecutionShouldCreateSuccessEmbed.verified.txt
+++ b/BotDeScans.UnitTests/Snapshots/Features.Titles.List.CommandsTests.GivenSuccessExecutionShouldCreateSuccessEmbed.verified.txt
@@ -1,0 +1,17 @@
+﻿{
+  Title: {
+    Value: Lista de obras,
+    HasValue: true
+  },
+  Description: {
+    Value:
+1. AAA
+2. BBB
+3. CCC,
+    HasValue: true
+  },
+  Colour: {
+    Value: Green,
+    HasValue: true
+  }
+}

--- a/BotDeScans.UnitTests/Specs/Features/References/List/CommandsTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/References/List/CommandsTests.cs
@@ -62,6 +62,40 @@ public class CommandsTests : UnitTest
         }
 
         [Fact]
+        public async Task GivenErrorRequestShouldReturnSuccess()
+        {
+            A.CallTo(() => fixture
+                .FreezeFake<Handler>()
+                .ExecuteAsync(A<int>.Ignored, cancellationToken))
+                .Returns(FluentResults.Result.Fail("some error"));
+
+            var result = await commands.ExecuteAsync(fixture.Create<int>());
+
+            result.IsSuccess.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GivenErrorRequestShouldReturnExpectedEmbed()
+        {
+            Embed embedResult = null!;
+
+            A.CallTo(() => fixture
+                .FreezeFake<Handler>()
+                .ExecuteAsync(A<int>.Ignored, cancellationToken))
+                .Returns(FluentResults.Result.Fail("some error"));
+
+            A.CallTo(() => fixture
+                .FreezeFake<IFeedbackService>()
+                .SendContextualEmbedAsync(A<Embed>.Ignored, A<FeedbackMessageOptions>.Ignored, cancellationToken))
+                .Invokes((Embed embed, FeedbackMessageOptions _, CancellationToken _) => embedResult = embed);
+
+            await commands.ExecuteAsync(fixture.Create<int>());
+
+            embedResult.Should().NotBeNull();
+            await Verify(embedResult);
+        }
+
+        [Fact]
         public async Task GivenErrorToSendFeedbackMessageShouldReturnError()
         {
             A.CallTo(() => fixture

--- a/BotDeScans.UnitTests/Specs/Features/References/Update/RequestTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/References/Update/RequestTests.cs
@@ -1,0 +1,33 @@
+﻿using BotDeScans.App.Features.References.Update;
+using BotDeScans.App.Models.Entities;
+
+namespace BotDeScans.UnitTests.Specs.Features.References.Update;
+
+public class RequestTests : UnitTest
+{
+    public class ReferenceValue : RequestTests
+    {
+        [Fact]
+        public void GivenRawValueAsGuidShouldReturnExpectedValue()
+        {
+            const string EXPECTED_RESULT = "801513ba-a712-498c-8f57-cae55b38cc92";
+
+            var result = new Request(fixture.Create<int>(), fixture.Create<ExternalReference>(), EXPECTED_RESULT);
+
+            result.ReferenceValue.Should().Be(EXPECTED_RESULT);
+        }
+
+        [Theory]
+        [InlineData("https://mangadex.org/title/801513ba-a712-498c-8f57-cae55b38cc92")]
+        [InlineData("https://mangadex.org/title/801513ba-a712-498c-8f57-cae55b38cc92/")]
+        [InlineData("https://mangadex.org/title/801513ba-a712-498c-8f57-cae55b38cc92/berserk")]
+        public void GivenRawValueAsDexLinkShouldReturnExpectedValue(string link)
+        {
+            const string EXPECTED_RESULT = "801513ba-a712-498c-8f57-cae55b38cc92";
+
+            var result = new Request(fixture.Create<int>(), fixture.Create<ExternalReference>(), link);
+
+            result.ReferenceValue.Should().Be(EXPECTED_RESULT);
+        }
+    }
+}

--- a/BotDeScans.UnitTests/Specs/Features/Titles/List/CommandsTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/Titles/List/CommandsTests.cs
@@ -1,0 +1,145 @@
+﻿using BotDeScans.App.Features.Titles.List;
+using BotDeScans.App.Infra.Repositories;
+using BotDeScans.App.Models.Entities;
+using Remora.Discord.API.Abstractions.Objects;
+using Remora.Discord.API.Objects;
+using Remora.Discord.Commands.Feedback.Messages;
+using Remora.Discord.Commands.Feedback.Services;
+using Remora.Discord.Extensions.Errors;
+using Remora.Rest.Core;
+
+namespace BotDeScans.UnitTests.Specs.Features.Titles.List;
+
+public class CommandsTests : UnitTest
+{
+    private readonly Commands commands;
+    private readonly List<Title> titles = [];
+
+    public CommandsTests()
+    {
+        titles.Add(fixture.Build<Title>().With(x => x.Name, "AAA").With(x => x.Id, 2).Create());
+        titles.Add(fixture.Build<Title>().With(x => x.Name, "BBB").With(x => x.Id, 3).Create());
+        titles.Add(fixture.Build<Title>().With(x => x.Name, "CCC").With(x => x.Id, 1).Create());
+        
+        fixture.FreezeFake<IFeedbackService>();
+        fixture.FreezeFake<TitleRepository>();
+
+        commands = fixture.CreateCommand<Commands>(cancellationToken);
+
+        A.CallTo(() => fixture
+            .FreezeFake<TitleRepository>()
+            .GetTitlesAsync(cancellationToken))
+            .Returns(titles);
+    }
+
+    [Fact]
+    public async Task GivenSuccessExecutionShouldReturnSuccess()
+    {
+        var result = await commands.List();
+
+        result.IsSuccess.Should().BeTrue();
+        AssertWarningMessage(times: 0);
+        AssertEmbedMessage(times: 1);
+    }
+
+    [Fact]
+    public async Task GivenSuccessExecutionShouldCreateSuccessEmbed()
+    {
+        Embed embedResult = null!;
+        A.CallTo(() => fixture
+            .FreezeFake<IFeedbackService>()
+            .SendContextualEmbedAsync(A<Embed>.Ignored, A<FeedbackMessageOptions>.Ignored, cancellationToken))
+            .Invokes((Embed embed, FeedbackMessageOptions _, CancellationToken _) => embedResult = embed);
+
+        await commands.List();
+
+        embedResult.Should().NotBeNull();
+        AssertWarningMessage(times: 0);
+        AssertEmbedMessage(times: 1);
+
+        await Verify(embedResult);
+    }
+
+    [Fact]
+    public async Task GivenNoTitlesShouldReturnSuccess()
+    {
+        A.CallTo(() => fixture
+            .FreezeFake<TitleRepository>()
+            .GetTitlesAsync(cancellationToken))
+            .Returns([]);
+
+        var result = await commands.List();
+
+        result.IsSuccess.Should().BeTrue();
+        AssertWarningMessage(times: 1);
+        AssertEmbedMessage(times: 0);
+    }
+
+    [Fact]
+    public async Task GivenErrorToCreateInteractionWhenNoTitlesShouldReturnError()
+    {
+        A.CallTo(() => fixture
+            .FreezeFake<TitleRepository>()
+            .GetTitlesAsync(cancellationToken))
+            .Returns([]);
+
+        A.CallTo(() => fixture
+            .FreezeFake<IFeedbackService>()
+            .SendContextualWarningAsync(
+                 "Não há obras cadastradas.", 
+                A<Snowflake?>.Ignored, 
+                A<FeedbackMessageOptions>.Ignored, 
+                cancellationToken))
+            .Returns(Remora.Results.Result<IReadOnlyList<IMessage>>
+                .FromError(new ValidationError("prop", "reason")));
+
+        var result = await commands.List();
+
+        result.IsSuccess.Should().BeFalse();
+        AssertWarningMessage(times: 1);
+        AssertEmbedMessage(times: 0);
+    }
+
+    [Fact]
+    public async Task GivenErrorToCreateInteractionShouldReturnError()
+    {
+        A.CallTo(() => fixture
+            .FreezeFake<IFeedbackService>()
+            .SendContextualEmbedAsync(A<Embed>.Ignored, A<FeedbackMessageOptions>.Ignored, cancellationToken))
+            .Returns(Remora.Results.Result<IMessage>.FromError(new ValidationError("prop", "reason")));
+        
+        var result = await commands.List();
+
+        result.IsSuccess.Should().BeFalse();
+        AssertWarningMessage(times: 0);
+        AssertEmbedMessage(times: 1);
+    }
+
+    private void AssertWarningMessage(int times)
+    {
+        A.CallTo(() => fixture
+            .FreezeFake<IFeedbackService>()
+            .SendContextualWarningAsync(
+                 "Não há obras cadastradas.",
+                A<Snowflake?>.Ignored,
+                A<FeedbackMessageOptions>.Ignored,
+                cancellationToken))
+            .MustHaveHappened(times, Times.Exactly);
+
+        Fake.GetCalls(fixture.FreezeFake<IFeedbackService>())
+            .Where(x => x.Method.Name == nameof(IFeedbackService.SendContextualWarningAsync))
+            .Should().HaveCount(times);
+    }
+
+    private void AssertEmbedMessage(int times)
+    {
+        A.CallTo(() => fixture
+            .FreezeFake<IFeedbackService>()
+            .SendContextualEmbedAsync(A<Embed>.Ignored, A<FeedbackMessageOptions>.Ignored, cancellationToken))
+            .MustHaveHappened(times, Times.Exactly);
+
+        Fake.GetCalls(fixture.FreezeFake<IFeedbackService>())
+            .Where(x => x.Method.Name == nameof(IFeedbackService.SendContextualEmbedAsync))
+            .Should().HaveCount(times);
+    }
+}

--- a/BotDeScans.UnitTests/Specs/Infra/Repositories/TitleRepositoryTests.cs
+++ b/BotDeScans.UnitTests/Specs/Infra/Repositories/TitleRepositoryTests.cs
@@ -61,7 +61,7 @@ public class TitleRepositoryTests : UnitPersistenceTest
             var result = await repository.GetTitlesAsync(cancellationToken);
 
             result.Should().HaveCount(expectedTitles.Count).And
-                           .ContainInOrder(expectedTitles);
+                           .BeEquivalentTo(expectedTitles);
         }
     }
 }

--- a/BotDeScans.UnitTests/Specs/Infra/Repositories/TitleRepositoryTests.cs
+++ b/BotDeScans.UnitTests/Specs/Infra/Repositories/TitleRepositoryTests.cs
@@ -41,4 +41,27 @@ public class TitleRepositoryTests : UnitPersistenceTest
             result?.References.Should().BeEquivalentTo([expectedReference]);
         }
     }
+
+    public class GetTitlesAsync : TitleRepositoryTests
+    {
+        [Fact]
+        public async Task GivenTitlesInDatabaseShouldReturnAllTitles()
+        {
+            var expectedTitles = Enumerable.Range(1, 5)
+                .Select(i => fixture.Build<Title>()
+                    .With(x => x.Id, i)
+                    .With(x => x.References, [])
+                    .With(x => x.SkipSteps, [])
+                    .Create())
+                .ToList();
+
+            await fixture.Freeze<DatabaseContext>().AddRangeAsync(expectedTitles, cancellationToken);
+            await fixture.Freeze<DatabaseContext>().SaveChangesAsync(cancellationToken);
+
+            var result = await repository.GetTitlesAsync(cancellationToken);
+
+            result.Should().HaveCount(expectedTitles.Count).And
+                           .ContainInOrder(expectedTitles);
+        }
+    }
 }


### PR DESCRIPTION
This pull request refactors the logic for listing titles in the bot, improves test coverage for reference parsing and title listing, and introduces a new repository method for fetching titles. The most important changes are the migration of data access from `DatabaseContext` to a dedicated repository, enhancements to unit tests for both references and titles, and improved error handling and feedback in the command layer.

**Refactoring and Data Access Improvements:**

* The `Commands` class in `BotDeScans.App.Features.Titles.List` now uses dependency injection for `IFeedbackService` and the new `TitleRepository`, replacing direct usage of `DatabaseContext`. This change improves separation of concerns and testability.
* The `TitleRepository` class introduces a new method `GetTitlesAsync` to fetch all titles with related entities, centralizing data access logic.

**Command Logic and Feedback Handling:**

* The logic for listing titles now uses `TitleRepository.GetTitlesAsync`, sorts titles by name, and handles the case where no titles exist by sending a contextual warning.

**Unit Test Enhancements:**

* Added comprehensive unit tests for the `Commands` class, covering successful listing, embed creation, no titles scenario, and error handling for feedback interactions.
* Added unit tests for the new `GetTitlesAsync` method in `TitleRepository`, verifying correct retrieval of titles from the database.
* Added unit tests for the `Request.ReferenceValue` logic, ensuring correct parsing of GUIDs and MangaDex links.

**Snapshot Updates:**

* Updated and added snapshot files for embed results in both error and success scenarios, ensuring UI feedback matches expectations. [[1]](diffhunk://#diff-a582167cefa89946603ebcf6cceba1c53f4d45fbaa6eaf8634a999ceb0a939a9R1-R19) [[2]](diffhunk://#diff-50517f6d68e99c2e684b4616ad571e5271b61a56fc7e663c7845a963aa3780e3R1-R17)

**Reference Parsing Logic:**

* Minor refactor to the `ReferenceValue` property for improved readability and testability.