### PR TITLE
IConfiguration Extension Methods Refactor and Tests

### DIFF
--- a/BotDeScans.App/Extensions/ConfigurationExtensions.cs
+++ b/BotDeScans.App/Extensions/ConfigurationExtensions.cs
@@ -12,14 +12,22 @@ public static class ConfigurationExtensions
 
     public static Result<T> GetRequiredValueAsResult<T>(this IConfiguration configuration, string key)
     {
-        var value = configuration.GetValue<string?>(key, null);
+        var value = configuration.GetValue<string?>(key);
+
         if (string.IsNullOrWhiteSpace(value))
             return Result.Fail($"'{key}' config value not found.");
 
-        return Result.Try(
-            () => (T)TypeDescriptor.GetConverter(typeof(T)).ConvertFrom(value)!,
-             _ => new Error($"'{key}' config value contains a not supported value."));
-
+        try
+        {
+            var converter = TypeDescriptor.GetConverter(typeof(T));
+            var convertedValue = (T)converter.ConvertFromInvariantString(value)!;
+            return Result.Ok(convertedValue);
+        }
+        catch (Exception)
+        {
+            var errorMessage = $"'{key}' config value contains an unsupported value.";
+            return Result.Fail(errorMessage);
+        }
     }
 
     public static T[] GetValues<T>(this IConfiguration configuration, string key) =>

--- a/BotDeScans.App/Features/Publish/Interaction/Steps/StepsService.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Steps/StepsService.cs
@@ -32,9 +32,7 @@ public class StepsService(IConfiguration configuration, IEnumerable<IStep> allSt
     /// </summary>
     private static List<IStep> GetConfigurationSteps(IConfiguration configuration, IEnumerable<IStep> allSteps)
     {
-        var stepNames = configuration.GetValues<StepName>(
-            key: STEPS_KEY,
-            value => Enum.Parse(typeof(StepName), value));
+        var stepNames = configuration.GetValues<StepName>(key: STEPS_KEY);
 
         return allSteps
             .Where(step => stepNames.Contains(step.Name))

--- a/BotDeScans.App/Services/Initializations/Factories/BoxClientFactory.cs
+++ b/BotDeScans.App/Services/Initializations/Factories/BoxClientFactory.cs
@@ -15,7 +15,7 @@ public class BoxClientFactory(IConfiguration configuration) : ClientFactory<IBox
     public const string CREDENTIALS_FILE_NAME = "box.json";
 
     public override bool Enabled => configuration
-        .GetValues<StepName>("Settings:Publish:Steps", value => Enum.Parse(typeof(StepName), value))
+        .GetValues<StepName>("Settings:Publish:Steps")
         .Any(x => x is StepName.UploadPdfBox or StepName.UploadZipBox);
 
     [ExcludeFromCodeCoverage(Justification = "BoxJWTAuth is not mockable  - all code relies this class.")]

--- a/BotDeScans.App/Services/Initializations/Factories/GoogleBloggerClientFactory.cs
+++ b/BotDeScans.App/Services/Initializations/Factories/GoogleBloggerClientFactory.cs
@@ -20,7 +20,7 @@ public class GoogleBloggerClientFactory(
     public const string CREDENTIALS_FILE_NAME = "blogger.json";
 
     public override bool Enabled => configuration
-        .GetValues<StepName>("Settings:Publish:Steps", value => Enum.Parse(typeof(StepName), value))
+        .GetValues<StepName>("Settings:Publish:Steps")
         .Any(x => x == StepName.PublishBlogspot);
 
     public override async Task<Result<BloggerService>> CreateAsync(

--- a/BotDeScans.App/Services/Initializations/Factories/MangaDexClientFactory.cs
+++ b/BotDeScans.App/Services/Initializations/Factories/MangaDexClientFactory.cs
@@ -14,7 +14,7 @@ public class MangaDexClientFactory(
     : ClientFactory<MangaDexAccessToken>
 {
     public override bool Enabled => configuration
-        .GetValues<StepName>("Settings:Publish:Steps", value => Enum.Parse(typeof(StepName), value))
+        .GetValues<StepName>("Settings:Publish:Steps")
         .Any(x => x == StepName.UploadMangadex);
 
     public override async Task<Result<MangaDexAccessToken>> CreateAsync(CancellationToken cancellationToken)

--- a/BotDeScans.App/Services/Initializations/Factories/MegaClientFactory.cs
+++ b/BotDeScans.App/Services/Initializations/Factories/MegaClientFactory.cs
@@ -11,7 +11,7 @@ namespace BotDeScans.App.Services.Initializations.Factories;
 public class MegaClientFactory(IConfiguration configuration) : ClientFactory<IMegaApiClient>
 {
     public override bool Enabled => configuration
-        .GetValues<StepName>("Settings:Publish:Steps", value => Enum.Parse(typeof(StepName), value))
+        .GetValues<StepName>("Settings:Publish:Steps")
         .Any(x => x is StepName.UploadPdfMega or StepName.UploadZipMega);
 
     public override async Task<Result<IMegaApiClient>> CreateAsync(CancellationToken cancellationToken)

--- a/BotDeScans.App/Services/Initializations/Factories/SakuraMangasClientFactory.cs
+++ b/BotDeScans.App/Services/Initializations/Factories/SakuraMangasClientFactory.cs
@@ -10,7 +10,7 @@ namespace BotDeScans.App.Services.Initializations.Factories;
 public class SakuraMangasClientFactory(IConfiguration configuration) : ClientFactory<SakuraMangasService>
 {
     public override bool Enabled => configuration
-        .GetValues<StepName>("Settings:Publish:Steps", value => Enum.Parse(typeof(StepName), value))
+        .GetValues<StepName>("Settings:Publish:Steps")
         .Any(x => x is StepName.UploadSakuraMangas);
 
     public override Task<Result<SakuraMangasService>> CreateAsync(CancellationToken cancellationToken)

--- a/BotDeScans.App/Services/Initializations/SetupStepsService.cs
+++ b/BotDeScans.App/Services/Initializations/SetupStepsService.cs
@@ -4,6 +4,7 @@ using BotDeScans.App.Features.Publish.Interaction.Steps.Enums;
 using BotDeScans.App.Models.Entities.Enums;
 using FluentResults;
 using Microsoft.Extensions.Configuration;
+
 namespace BotDeScans.App.Services.Initializations;
 
 public class SetupStepsService(
@@ -16,7 +17,7 @@ public class SetupStepsService(
     {
         Console.WriteLine("Validating Publish Steps...");
 
-        var expectedStepsAsString = configuration.GetValues<string>(STEPS_KEY, value => value);
+        var expectedStepsAsString = configuration.GetValues<string>(STEPS_KEY);
         if (expectedStepsAsString.Length == 0)
             return Result.Fail($"Não foi encontrado nenhum passo de publicação em '{STEPS_KEY}'.");
 

--- a/BotDeScans.UnitTests/Extensions/FixtureExtensions.cs
+++ b/BotDeScans.UnitTests/Extensions/FixtureExtensions.cs
@@ -3,6 +3,7 @@ using FakeItEasy.Creation;
 using Microsoft.Extensions.Configuration;
 using Remora.Commands.Groups;
 using System.Reflection;
+
 namespace BotDeScans.UnitTests.Extensions;
 
 public static class FixtureExtensions
@@ -65,8 +66,6 @@ public static class FixtureExtensions
 
     public static IConfiguration FreezeFakeConfiguration(this IFixture fixture, string key, string? value)
     {
-        fixture.FreezeFake<IConfiguration>();
-
         var fakeSection = A.Fake<IConfigurationSection>();
         A.CallTo(() => fakeSection.Value).Returns(value);
 
@@ -80,8 +79,6 @@ public static class FixtureExtensions
 
     public static IConfiguration FreezeFakeConfiguration(this IFixture fixture, string key, IEnumerable<string> values)
     {
-        fixture.FreezeFake<IConfiguration>();
-
         var innerFakeSections = values.Select(value =>
         {
             var innerFakeSection = A.Fake<IConfigurationSection>();

--- a/BotDeScans.UnitTests/Extensions/FixtureExtensions.cs
+++ b/BotDeScans.UnitTests/Extensions/FixtureExtensions.cs
@@ -63,7 +63,7 @@ public static class FixtureExtensions
         return fixture.Freeze<T[]>();
     }
 
-    public static void FreezeFakeConfiguration(this IFixture fixture, string key, string? value)
+    public static IConfiguration FreezeFakeConfiguration(this IFixture fixture, string key, string? value)
     {
         fixture.FreezeFake<IConfiguration>();
 
@@ -74,9 +74,11 @@ public static class FixtureExtensions
             .FreezeFake<IConfiguration>()
             .GetSection(key))
             .Returns(fakeSection);
+
+        return fixture.FreezeFake<IConfiguration>();
     }
 
-    public static void FreezeFakeConfiguration(this IFixture fixture, string key, IEnumerable<string> values)
+    public static IConfiguration FreezeFakeConfiguration(this IFixture fixture, string key, IEnumerable<string> values)
     {
         fixture.FreezeFake<IConfiguration>();
 
@@ -96,6 +98,8 @@ public static class FixtureExtensions
 
         A.CallTo(() => baseFakeSection.GetChildren())
             .Returns(innerFakeSections);
+
+        return fixture.FreezeFake<IConfiguration>();
     }
 
     public static T CreateCommand<T>(this IFixture fixture, CancellationToken cancellationToken)

--- a/BotDeScans.UnitTests/Specs/Extensions/ConfigurationExtensionsTests.cs
+++ b/BotDeScans.UnitTests/Specs/Extensions/ConfigurationExtensionsTests.cs
@@ -88,8 +88,7 @@ public abstract class ConfigurationExtensionsTests : UnitTest
                    .GetSection(SECTION))
                    .Returns(null);
 
-            var result = fixture
-                   .FreezeFake<IConfiguration>()
+            fixture.FreezeFake<IConfiguration>()
                    .GetValues<string>(SECTION)
                    .Should().BeEmpty();
         }
@@ -147,6 +146,31 @@ public abstract class ConfigurationExtensionsTests : UnitTest
             fixture.FreezeFakeConfiguration(SECTION, values)
                    .GetValues<StepName>(SECTION)
                    .Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Fact]
+        public void GivenSomeInvalidValueShouldIgnoreThem()
+        {
+            const string SECTION = "SomeSection";
+
+            var values = new string[] { "1", "invalid", "2", "invalid" };
+            var expectedResult = new int[] { 1, 2 };
+
+            fixture.FreezeFakeConfiguration(SECTION, values)
+                   .GetValues<int>(SECTION)
+                   .Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Fact]
+        public void GivenOnlyInvalidValueShouldReturnEmpty()
+        {
+            const string SECTION = "SomeSection";
+
+            var values = new string[] { "invalid", "invalid" };
+
+            fixture.FreezeFakeConfiguration(SECTION, values)
+                   .GetValues<int>(SECTION)
+                   .Should().BeEmpty();
         }
     }
 }

--- a/BotDeScans.UnitTests/Specs/Extensions/ConfigurationExtensionsTests.cs
+++ b/BotDeScans.UnitTests/Specs/Extensions/ConfigurationExtensionsTests.cs
@@ -55,7 +55,7 @@ public abstract class ConfigurationExtensionsTests : UnitTest
         public void GivenInvalidValueForATypeShouldReturnFailResult()
         {
             const string KEY = "SomeKey";
-            const string ERROR = $"'{KEY}' config value contains a not supported value.";
+            const string ERROR = $"'{KEY}' config value contains an unsupported value.";
 
             fixture.FreezeFakeConfiguration(KEY, "invalid-value")
                    .GetRequiredValueAsResult<int>(KEY)

--- a/BotDeScans.UnitTests/Specs/Extensions/ConfigurationExtensionsTests.cs
+++ b/BotDeScans.UnitTests/Specs/Extensions/ConfigurationExtensionsTests.cs
@@ -1,0 +1,152 @@
+﻿using BotDeScans.App.Extensions;
+using BotDeScans.App.Models.Entities.Enums;
+using Microsoft.Extensions.Configuration;
+using static FluentAssertions.FluentActions;
+
+namespace BotDeScans.UnitTests.Specs.Extensions;
+
+public abstract class ConfigurationExtensionsTests : UnitTest
+{
+    public class GetRequiredValue : ConfigurationExtensionsTests
+    {
+        [Fact]
+        public void GivenMissingKeyShouldThrowArgumentNullException()
+        {
+            const string KEY = "MissingKey";
+            const string ERROR = $"'{KEY}' config value not found. (Parameter 'key')";
+
+            Invoking(() => fixture
+                   .FreezeFakeConfiguration(KEY, null as string)
+                   .GetRequiredValue<string>(KEY))
+                   .Should().Throw<ArgumentNullException>()
+                   .WithMessage(ERROR);
+        }
+
+        [Fact]
+        public void GivenExistingKeyShouldReturnValue()
+        {
+            const string KEY = "ExistingKey";
+            const string VALUE = "ExpectedValue";
+
+            fixture.FreezeFakeConfiguration(KEY, VALUE)
+                   .GetRequiredValue<string>(KEY)
+                   .Should().Be(VALUE);
+        }
+    }
+
+    public class GetRequiredValueAsResult : ConfigurationExtensionsTests
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData(null)]
+        public void GivenNotFilledValShouldReturnFailResult(string? value)
+        {
+            const string KEY = "SomeKey";
+            const string ERROR = $"'{KEY}' config value not found.";
+
+            fixture.FreezeFakeConfiguration(KEY, value)
+                   .GetRequiredValueAsResult<string>(KEY)
+                   .Should().BeFailure()
+                   .And.HaveError(ERROR);
+        }
+
+        [Fact]
+        public void GivenInvalidValueForATypeShouldReturnFailResult()
+        {
+            const string KEY = "SomeKey";
+            const string ERROR = $"'{KEY}' config value contains a not supported value.";
+
+            fixture.FreezeFakeConfiguration(KEY, "invalid-value")
+                   .GetRequiredValueAsResult<int>(KEY)
+                   .Should().BeFailure()
+                   .And.HaveError(ERROR);
+        }
+
+        [Fact]
+        public void GivenValidValueShouldConvertAndReturnIt()
+        {
+            const string KEY = "SomeKey";
+            const string VALUE = nameof(StepName.Setup);
+
+            fixture.FreezeFakeConfiguration(KEY, VALUE)
+                   .GetRequiredValueAsResult<StepName>(KEY)
+                   .Should().BeSuccess()
+                   .And.HaveValue(StepName.Setup);
+        }
+    }
+
+    public class GetValues : ConfigurationExtensionsTests
+    {
+        [Fact]
+        public void GivenNotFoundSectionShouldReturnEmpty()
+        {
+            const string SECTION = "SomeSection";
+
+            A.CallTo<IConfigurationSection?>(() => fixture
+                   .FreezeFake<IConfiguration>()
+                   .GetSection(SECTION))
+                   .Returns(null);
+
+            var result = fixture
+                   .FreezeFake<IConfiguration>()
+                   .GetValues<string>(SECTION)
+                   .Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GivenEmptyListShouldReturnEmpty()
+        {
+            const string SECTION = "SomeSection";
+            
+            fixture.FreezeFakeConfiguration(SECTION, [])
+                   .GetValues<string>(SECTION)
+                   .Should().BeEmpty();
+        }
+
+        [Fact]
+        public void GivenValidValuesShouldReturnParsedDistinctValues()
+        {
+            const string SECTION = "SomeSection";
+            var values = new string[]
+            {
+                nameof(StepName.Download),
+                nameof(StepName.Compress)
+            };
+
+            var expectedResult = new StepName[]
+            {
+                StepName.Download,
+                StepName.Compress
+            };
+
+            fixture.FreezeFakeConfiguration(SECTION, values)
+                   .GetValues<StepName>(SECTION)
+                   .Should().BeEquivalentTo(expectedResult);
+        }
+
+        [Fact]
+        public void GivenRepeatedValuesShouldIgnoreThem()
+        {
+            const string SECTION = "SomeSection";
+            var values = new string[]
+            {
+                nameof(StepName.Download),
+                nameof(StepName.Download),
+                nameof(StepName.Download),
+                nameof(StepName.Compress),
+                nameof(StepName.Compress)
+            };
+
+            var expectedResult = new StepName[]
+            {
+                StepName.Download,
+                StepName.Compress
+            };
+
+            fixture.FreezeFakeConfiguration(SECTION, values)
+                   .GetValues<StepName>(SECTION)
+                   .Should().BeEquivalentTo(expectedResult);
+        }
+    }
+}


### PR DESCRIPTION
This pull request refactors and simplifies configuration value retrieval logic throughout the codebase, focusing on the `GetValues` extension method and its usage. The changes remove unnecessary parsing logic, improve error handling, and add comprehensive unit tests to ensure correctness.

### Refactoring and simplification of configuration methods

* Refactored `GetValues<T>` in `ConfigurationExtensions.cs` to remove the need for a custom parser function; it now directly deserializes configuration sections to lists of type `T`, ensuring distinctness and handling nulls gracefully. Also improved error handling in `GetRequiredValueAsResult<T>` and simplified value conversion logic.
* Updated all usages of `GetValues<T>` across service factories and step services to use the new, simplified method signature, removing redundant enum parsing. [[1]](diffhunk://#diff-ab04bddaa9b5d18b241f2c525fecbc82e024f1d538a59125469dfde1b458deb0L35-R35) [[2]](diffhunk://#diff-075117436e58ecdffe5eff24c9dacd30d71b61ba34226cd9c95b59159716ac85L18-R18) [[3]](diffhunk://#diff-099a456e7301f02c7efe1cb09cc99554ef6801e5b379d927581a38ed1cada7a6L23-R23) [[4]](diffhunk://#diff-d85ca2f41cbcd8a31ce37248680a48f4d59b92b20a24873f20c617b7452a8899L17-R17) [[5]](diffhunk://#diff-dbef60244d1e0c529bc0620028d8ae3381d05a920552fee5bcce23b8e3f73be0L14-R14) [[6]](diffhunk://#diff-3784875f9de8a30b4843c959e7115c3ca06ce8eb7bab4c84ce9c6de174cd3977L13-R13) [[7]](diffhunk://#diff-c711d7ae115c2b46143c6b409c00d44efbdc67a3513a5fb035079d45d66484c2L19-R20)

### Testing improvements

* Added a new test suite `ConfigurationExtensionsTests` that thoroughly tests the updated configuration extension methods, including edge cases for missing keys, invalid values, and duplicate entries.
* Improved test helper methods in `FixtureExtensions.cs` to return the frozen `IConfiguration` instance, supporting the new test scenarios and making tests more expressive. [[1]](diffhunk://#diff-56bc4226b5a5bad9a429917823ddef6cc15e6dd38bf31e463fe55c25e2edddd5L66-L82) [[2]](diffhunk://#diff-56bc4226b5a5bad9a429917823ddef6cc15e6dd38bf31e463fe55c25e2edddd5R98-R99)

### Minor codebase cleanup

* Minor formatting and namespace import adjustments for consistency. [[1]](diffhunk://#diff-c711d7ae115c2b46143c6b409c00d44efbdc67a3513a5fb035079d45d66484c2R7) [[2]](diffhunk://#diff-56bc4226b5a5bad9a429917823ddef6cc15e6dd38bf31e463fe55c25e2edddd5R6)

These changes collectively make configuration retrieval more robust, maintainable, and easier to test.