### PR TITLE
Chore/update packages

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     - name: Restore Dependencies
       run: dotnet restore BotDeScans.sln

--- a/BotDeScans.App/BotDeScans.App.csproj
+++ b/BotDeScans.App/BotDeScans.App.csproj
@@ -25,31 +25,31 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Box.V2.Core" Version="10.5.0" />
+    <PackageReference Include="Box.V2.Core" Version="10.11.0" />
     <PackageReference Include="FluentResults" Version="4.0.0" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-    <PackageReference Include="Google.Apis.Auth" Version="1.73.0" />
-    <PackageReference Include="Google.Apis.Blogger.v3" Version="1.69.0.3796" />
-    <PackageReference Include="Google.Apis.Drive.v3" Version="1.73.0.3996" />
-    <PackageReference Include="Imageflow.AllPlatforms" Version="0.14.1" />
-    <PackageReference Include="itext.bouncy-castle-adapter" Version="9.5.0" />
-    <PackageReference Include="itext" Version="9.5.0" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.74.0" />
+    <PackageReference Include="Google.Apis.Blogger.v3" Version="1.73.0.4085" />
+    <PackageReference Include="Google.Apis.Drive.v3" Version="1.74.0.4135" />
+    <PackageReference Include="Imageflow.AllPlatforms" Version="0.15.1" />
+    <PackageReference Include="itext.bouncy-castle-adapter" Version="9.6.0" />
+    <PackageReference Include="itext" Version="9.6.0" />
     <PackageReference Include="LazyCache" Version="2.4.0" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-    <PackageReference Include="MangaDexSharp" Version="1.3.5" />
-    <PackageReference Include="MangaDexSharp.Utilities" Version="1.3.5" />
+    <PackageReference Include="MangaDexSharp" Version="1.3.7" />
+    <PackageReference Include="MangaDexSharp.Utilities" Version="1.3.7" />
     <PackageReference Include="MegaApiClient" Version="1.10.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.2">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
     <PackageReference Include="Remora.Discord" Version="2025.2.0" />
-    <PackageReference Include="ScottPlot" Version="5.1.57" />
-    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="ScottPlot" Version="5.1.58" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
@@ -57,8 +57,8 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="StringToExpression" Version="2.2.0" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.2" />
-    <PackageReference Include="System.Text.Json" Version="10.0.2" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.7" />
+    <PackageReference Include="System.Text.Json" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BotDeScans.App/BotDeScans.App.csproj
+++ b/BotDeScans.App/BotDeScans.App.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 	<Version>1.0.0-beta</Version>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <StartupObject>BotDeScans.App.Program</StartupObject>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -40,25 +40,25 @@
     <PackageReference Include="MangaDexSharp" Version="1.3.5" />
     <PackageReference Include="MangaDexSharp.Utilities" Version="1.3.5" />
     <PackageReference Include="MegaApiClient" Version="1.10.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.12">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.12" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.12" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.2" />
     <PackageReference Include="Remora.Discord" Version="2025.2.0" />
     <PackageReference Include="ScottPlot" Version="5.1.57" />
-    <PackageReference Include="Serilog" Version="4.2.0" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="StringToExpression" Version="2.2.0" />
-    <PackageReference Include="System.Drawing.Common" Version="9.0.12" />
-    <PackageReference Include="System.Text.Json" Version="9.0.12" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.2" />
+    <PackageReference Include="System.Text.Json" Version="10.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BotDeScans.App/BotDeScans.App.csproj
+++ b/BotDeScans.App/BotDeScans.App.csproj
@@ -29,26 +29,26 @@
     <PackageReference Include="FluentResults" Version="4.0.0" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
-    <PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
-    <PackageReference Include="Google.Apis.Blogger.v3" Version="1.68.0.2925" />
-    <PackageReference Include="Google.Apis.Drive.v3" Version="1.69.0.3769" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.73.0" />
+    <PackageReference Include="Google.Apis.Blogger.v3" Version="1.69.0.3796" />
+    <PackageReference Include="Google.Apis.Drive.v3" Version="1.73.0.3996" />
     <PackageReference Include="Imageflow.AllPlatforms" Version="0.14.1" />
-    <PackageReference Include="itext.bouncy-castle-adapter" Version="9.1.0" />
-    <PackageReference Include="itext" Version="9.1.0" />
+    <PackageReference Include="itext.bouncy-castle-adapter" Version="9.5.0" />
+    <PackageReference Include="itext" Version="9.5.0" />
     <PackageReference Include="LazyCache" Version="2.4.0" />
     <PackageReference Include="LazyCache.AspNetCore" Version="2.4.0" />
-    <PackageReference Include="MangaDexSharp" Version="1.3.1" />
-    <PackageReference Include="MangaDexSharp.Utilities" Version="1.3.1" />
-    <PackageReference Include="MegaApiClient" Version="1.10.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">
+    <PackageReference Include="MangaDexSharp" Version="1.3.5" />
+    <PackageReference Include="MangaDexSharp.Utilities" Version="1.3.5" />
+    <PackageReference Include="MegaApiClient" Version="1.10.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.12" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.12">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
-    <PackageReference Include="Remora.Discord" Version="2024.3.0" />
-    <PackageReference Include="ScottPlot" Version="5.0.55" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.12" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.12" />
+    <PackageReference Include="Remora.Discord" Version="2025.2.0" />
+    <PackageReference Include="ScottPlot" Version="5.1.57" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />
@@ -57,8 +57,8 @@
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="StringToExpression" Version="2.2.0" />
-    <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
-    <PackageReference Include="System.Text.Json" Version="9.0.4" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.12" />
+    <PackageReference Include="System.Text.Json" Version="9.0.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BotDeScans.App/Services/ChartService.cs
+++ b/BotDeScans.App/Services/ChartService.cs
@@ -1,5 +1,6 @@
 ﻿using BotDeScans.App.Models.DTOs;
 using ScottPlot;
+
 namespace BotDeScans.App.Services;
 
 public class ChartService

--- a/BotDeScans.App/Services/Initializations/Factories/GoogleDriveClientFactory.cs
+++ b/BotDeScans.App/Services/Initializations/Factories/GoogleDriveClientFactory.cs
@@ -4,6 +4,7 @@ using FluentResults;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Drive.v3;
 using Google.Apis.Services;
+
 namespace BotDeScans.App.Services.Initializations.Factories;
 
 public class GoogleDriveClientFactory(GoogleWrapper googleWrapper) : ClientFactory<DriveService>
@@ -15,10 +16,12 @@ public class GoogleDriveClientFactory(GoogleWrapper googleWrapper) : ClientFacto
     public override async Task<Result<DriveService>> CreateAsync(CancellationToken cancellationToken = default)
     {
         await using var credentialStream = GetConfigFileAsStream(CREDENTIALS_FILE_NAME).Value;
-        var credential = await GoogleCredential.FromStreamAsync(credentialStream, cancellationToken);
+        var credential = await CredentialFactory.FromStreamAsync<ServiceAccountCredential>(credentialStream, cancellationToken);
+        var googleCredential = credential.ToGoogleCredential().CreateScoped(DriveService.Scope.Drive);
+
         return new DriveService(new BaseClientService.Initializer()
         {
-            HttpClientInitializer = credential.CreateScoped(DriveService.Scope.Drive).UnderlyingCredential,
+            HttpClientInitializer = googleCredential.UnderlyingCredential,
             ApplicationName = "BotDeScans"
         });
     }

--- a/BotDeScans.UnitTests/BotDeScans.UnitTests.csproj
+++ b/BotDeScans.UnitTests/BotDeScans.UnitTests.csproj
@@ -32,7 +32,6 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
     <PackageReference Include="FluentResults.Extensions.FluentAssertions" Version="2.2.1" />
-    <PackageReference Include="MegaApiClient" Version="1.10.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Verify" Version="29.2.0" />
     <PackageReference Include="Verify.FakeItEasy" Version="2.1.0" />

--- a/BotDeScans.UnitTests/BotDeScans.UnitTests.csproj
+++ b/BotDeScans.UnitTests/BotDeScans.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
 	<ImplicitUsings>enable</ImplicitUsings>
@@ -14,9 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="8.2.1" />
+    <PackageReference Include="Autofac" Version="9.0.0" />
     <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.18.1" />
-    <PackageReference Include="Bogus" Version="35.6.2" />
+    <PackageReference Include="Bogus" Version="35.6.5" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -25,26 +25,26 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FakeItEasy" Version="8.3.0" />
+    <PackageReference Include="FakeItEasy" Version="9.0.1" />
     <PackageReference Include="FakeItEasy.Analyzer.CSharp" Version="6.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
     <PackageReference Include="FluentResults.Extensions.FluentAssertions" Version="2.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Verify" Version="29.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Verify" Version="31.9.4" />
     <PackageReference Include="Verify.FakeItEasy" Version="2.1.0" />
-    <PackageReference Include="Verify.XunitV3" Version="29.2.0" />
-    <PackageReference Include="xunit.analyzers" Version="1.21.0">
+    <PackageReference Include="Verify.XunitV3" Version="31.9.4" />
+    <PackageReference Include="xunit.analyzers" Version="1.27.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="2.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-alpine-amd64 AS base
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-alpine-amd64 AS base
 WORKDIR /app
 RUN apk add --no-cache icu-libs icu-data-full dotnet6-runtime 
 RUN apk add --no-cache libgdiplus 
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
 WORKDIR /src
 COPY BotDeScans.App/BotDeScans.App.csproj ./BotDeScans.App/
 RUN dotnet restore "./BotDeScans.App/BotDeScans.App.csproj"


### PR DESCRIPTION
This pull request upgrades the project to .NET 10 and updates a wide range of dependencies and configurations to ensure compatibility. It also includes a minor refactor to the Google Drive client factory and makes small code style improvements. The most important changes are grouped below.

**.NET and Dependency Upgrades:**

* Upgraded the target framework for both the main application (`BotDeScans.App.csproj`) and unit tests (`BotDeScans.UnitTests.csproj`) from `net8.0` to `net10.0` to use the latest .NET features and improvements. [[1]](diffhunk://#diff-9644de1fa71ec8635045157fe474a5a178035a33bc13f6f160826463cb867957L6-R6) [[2]](diffhunk://#diff-27d00ccc4eb7608e81b6598d6019e1b0968a070dd39f96ebf4c711198068553bL4-R4)
* Updated the GitHub Actions workflow (`.github/workflows/dotnet.yml`) to use `dotnet-version: 10.0.x` for CI/CD compatibility.
* Updated the Dockerfile to use the .NET 10 runtime and SDK images for both build and runtime stages.
* Upgraded numerous NuGet package dependencies in both application and test projects to their latest major or minor versions, including Google APIs, Entity Framework Core, Serilog, Remora.Discord, ScottPlot, Autofac, FakeItEasy, Verify, Xunit, and others. [[1]](diffhunk://#diff-9644de1fa71ec8635045157fe474a5a178035a33bc13f6f160826463cb867957L28-R61) [[2]](diffhunk://#diff-27d00ccc4eb7608e81b6598d6019e1b0968a070dd39f96ebf4c711198068553bL17-R19) [[3]](diffhunk://#diff-27d00ccc4eb7608e81b6598d6019e1b0968a070dd39f96ebf4c711198068553bL28-R47)

**Code Refactoring and Compatibility:**

* Refactored `GoogleDriveClientFactory` to use `CredentialFactory.FromStreamAsync<ServiceAccountCredential>` and improved credential creation and scoping for DriveService, ensuring compatibility with updated Google API packages.

**Minor Code Style Improvements:**

* Added missing blank lines for code style consistency in `ChartService.cs` and `GoogleDriveClientFactory.cs`. [[1]](diffhunk://#diff-1f7bfa8e40f2a1ffa16c67fc572988abc09bbe0edf2a64d692ecf8c24c0ff50dR3) [[2]](diffhunk://#diff-2368847669e78c36c2b10c74a257e0d2d7c85ab4c7dcf4249eb8d6753b14f73eR7)