### PR TITLE
feat/parallel publish

### DIFF
--- a/BotDeScans.App/BotDeScans.App.csproj
+++ b/BotDeScans.App/BotDeScans.App.csproj
@@ -25,12 +25,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Box.V2.Core" Version="10.11.0" />
+    <PackageReference Include="Box.V2.Core" Version="10.12.0" />
     <PackageReference Include="FluentResults" Version="4.0.0" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageReference Include="Google.Apis.Auth" Version="1.74.0" />
-    <PackageReference Include="Google.Apis.Blogger.v3" Version="1.73.0.4085" />
+    <PackageReference Include="Google.Apis.Blogger.v3" Version="1.74.0.4085" />
     <PackageReference Include="Google.Apis.Drive.v3" Version="1.74.0.4135" />
     <PackageReference Include="Imageflow.AllPlatforms" Version="0.15.1" />
     <PackageReference Include="itext.bouncy-castle-adapter" Version="9.6.0" />
@@ -40,13 +40,13 @@
     <PackageReference Include="MangaDexSharp" Version="1.3.7" />
     <PackageReference Include="MangaDexSharp.Utilities" Version="1.3.7" />
     <PackageReference Include="MegaApiClient" Version="1.10.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <PackageReference Include="Remora.Discord" Version="2025.2.0" />
     <PackageReference Include="ScottPlot" Version="5.1.58" />
     <PackageReference Include="Serilog" Version="4.3.1" />
@@ -57,8 +57,7 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="StringToExpression" Version="2.2.0" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.7" />
-    <PackageReference Include="System.Text.Json" Version="10.0.7" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BotDeScans.App/Features/Publish/Interaction/DiscordPublisher.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/DiscordPublisher.cs
@@ -10,7 +10,6 @@ using Remora.Discord.Commands.Contexts;
 using Remora.Discord.Commands.Feedback.Services;
 using Remora.Rest.Core;
 using Remora.Results;
-using BotDeScans.App.Features.Publish.Interaction.Models;
 using System.Drawing;
 using System.Reflection;
 
@@ -24,6 +23,23 @@ public class DiscordPublisher(
     IDiscordRestInteractionAPI discordRestInteractionAPI,
     IDiscordRestChannelAPI discordRestChannelAPI)
 {
+    private readonly SemaphoreSlim _trackingLock = new(1, 1);
+
+    public virtual async Task<FluentResults.Result<State>> SynchronizedUpdateTrackingMessageAsync(
+        State state,
+        CancellationToken cancellationToken)
+    {
+        await _trackingLock.WaitAsync(cancellationToken);
+        try
+        {
+            return await UpdateTrackingMessageAsync(state, cancellationToken);
+        }
+        finally
+        {
+            _trackingLock.Release();
+        }
+    }
+
     public virtual async Task<FluentResults.Result<State>> UpdateTrackingMessageAsync(
         State state,
         CancellationToken cancellationToken)

--- a/BotDeScans.App/Features/Publish/Interaction/DiscordPublisher.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/DiscordPublisher.cs
@@ -126,8 +126,7 @@ public class DiscordPublisher(
         .GetProperties()
         .Where(property => property.GetCustomAttribute<ReleaseLinkAttribute>() is not null)
         .Select(property => new
-        {
-            Label = property.GetCustomAttribute<ReleaseLinkAttribute>()!.Label,
+        { property.GetCustomAttribute<ReleaseLinkAttribute>()!.Label,
             Link = property.GetValue(publishState, null)?.ToString()
         })
         .Where(x => !string.IsNullOrWhiteSpace(x.Link))

--- a/BotDeScans.App/Features/Publish/Interaction/Handler.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Handler.cs
@@ -39,7 +39,7 @@ public class Handler(
         currentState = managementExecution.State;
         currentResult = managementExecution.Result;
 
-        // Phase 2: Conversion steps (ZipFiles, PdfFiles, …) — run in parallel with I/O throttle.
+        // Phase 2: Conversion steps (ZipFiles, PdfFiles, …) — run in parallel.
         if (conversionSteps.Count > 0)
         {
             var conversionExecution = await RunParallelConversionAsync(

--- a/BotDeScans.App/Features/Publish/Interaction/Handler.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Handler.cs
@@ -206,6 +206,7 @@ public class Handler(
             MangaDexLink = updated.MangaDexLink ?? @base.MangaDexLink,
             SakuraMangasLink = updated.SakuraMangasLink ?? @base.SakuraMangasLink,
             BloggerLink = updated.BloggerLink ?? @base.BloggerLink,
+            BloggerImageAsBase64 = updated.BloggerImageAsBase64 ?? @base.BloggerImageAsBase64,
         };
 
     private async Task<Result<State>> RunValidationAsync(

--- a/BotDeScans.App/Features/Publish/Interaction/Handler.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Handler.cs
@@ -2,7 +2,6 @@
 using BotDeScans.App.Features.Publish.Interaction.Models;
 using BotDeScans.App.Features.Publish.Interaction.Steps;
 using BotDeScans.App.Features.Publish.Interaction.Steps.Enums;
-using BotDeScans.App.Models.Entities.Enums;
 using FluentResults;
 using Serilog;
 using System.Diagnostics;
@@ -83,7 +82,7 @@ public class Handler(
     }
 
     // Runs steps sequentially, used for management and validation phases.
-    private async Task<(Result Result, State State, bool ShouldStop)> RunSequentialChainAsync(
+    private static async Task<(Result Result, State State, bool ShouldStop)> RunSequentialChainAsync(
         Result aggregate,
         State state,
         IEnumerable<(IStep Step, StepInfo Info)> chain,
@@ -125,22 +124,22 @@ public class Handler(
         CancellationToken cancellationToken)
     {
         var items = conversionSteps.ToList();
+        var tracker = new ParallelStepsTracker(state, discordPublisher.SynchronizedUpdateTrackingMessageAsync);
+
         var results = await Task.WhenAll(
-            items.Select(item => RunStepAsync((item.Step, item.Info), state, cancellationToken)));
+            items.Select(item => RunStepParallelAsync((item.Step, item.Info), state, tracker, cancellationToken)));
 
-        foreach (var (stepResult, item) in results.Zip(items))
-        {
-            if (stepResult.IsSuccess)
-                state = MergeStates(state, stepResult.Value);
+        foreach (var stepResult in results)
+            aggregate = Result.Merge(aggregate, stepResult);
 
-            aggregate = Result.Merge(aggregate, stepResult.ToResult());
-        }
+        aggregate = Result.Merge(aggregate, tracker.AggregateTrackingResult);
 
         var hasFatalFailure = results
             .Zip(items, (r, item) => (Result: r, Step: (IStep)item.Step))
-            .Any(x => x.Result.IsFailed && !x.Step.ContinueOnError);
+            .Any(x => x.Result.IsFailed && !x.Step.ContinueOnError)
+            || tracker.AggregateTrackingResult.IsFailed;
 
-        return (aggregate, state, hasFatalFailure);
+        return (aggregate, tracker.CurrentState, hasFatalFailure);
     }
 
     // Runs publish steps grouped by Dependency, each group in parallel, groups sequentially.
@@ -159,26 +158,23 @@ public class Handler(
         foreach (var group in groups)
         {
             var groupItems = group.ToList();
+            var tracker = new ParallelStepsTracker(state, discordPublisher.SynchronizedUpdateTrackingMessageAsync);
 
-            // Run all steps in this group in parallel
-            var tasks = groupItems.Select(item =>
-                RunStepAsync((item.Step, item.Info), state, cancellationToken));
+            var results = await Task.WhenAll(
+                groupItems.Select(item =>
+                    RunStepParallelAsync((item.Step, item.Info), state, tracker, cancellationToken)));
 
-            var results = await Task.WhenAll(tasks);
-
-            // Merge states from parallel steps (each writes to disjoint properties)
             foreach (var stepResult in results)
-            {
-                if (stepResult.IsSuccess)
-                    state = MergeStates(state, stepResult.Value);
+                aggregate = Result.Merge(aggregate, stepResult);
 
-                aggregate = Result.Merge(aggregate, stepResult.ToResult());
-            }
+            aggregate = Result.Merge(aggregate, tracker.AggregateTrackingResult);
+            state = tracker.CurrentState;
 
             // Stop the entire DAG if any non-continuable step failed
             var hasFatalFailure = results
-                .Zip(groupItems, (r, item) => (Result: r, Step: item.Step))
-                .Any(x => x.Result.IsFailed && !x.Step.ContinueOnError);
+                .Zip(groupItems, (r, item) => (Result: r, item.Step))
+                .Any(x => x.Result.IsFailed && !x.Step.ContinueOnError)
+                || tracker.AggregateTrackingResult.IsFailed;
 
             if (hasFatalFailure)
                 return (aggregate, state);
@@ -245,6 +241,32 @@ public class Handler(
             : Result.Ok(result.IsSuccess ? result.Value with { Steps = handleResult.Value.Steps } : handleResult.Value);
     }
 
+    // Used by parallel phases: executes the step freely (no lock), then calls the tracker
+    // to atomically merge its output, update the StepInfo and send the Discord tracking message.
+    private static async Task<Result> RunStepParallelAsync(
+        (IStep Step, StepInfo Info) data,
+        State initialState,
+        ParallelStepsTracker tracker,
+        CancellationToken cancellationToken)
+    {
+        if (data.Info.Status == StepStatus.Skip)
+            return Result.Ok();
+
+        var stopwatch = Stopwatch.StartNew();
+        var result = await data.Step.SafeCallAsync(x => x.ExecuteAsync(initialState, cancellationToken));
+        stopwatch.Stop();
+
+        Log.Information(
+            "Publish step '{StepName}' ExecuteAsync finished in {ElapsedMilliseconds} ms with status {Status}.",
+            data.Step.Name,
+            stopwatch.ElapsedMilliseconds,
+            result.IsSuccess ? "Success" : "Failure");
+
+        var stepSnapshot = result.IsSuccess ? result.Value : initialState;
+        await tracker.ApplyAndNotifyAsync(result.ToResult(), data.Step, stepSnapshot, cancellationToken);
+        return result.ToResult();
+    }
+
     private async Task<Result<State>> HandleResult(
         Result result,
         IStep step,
@@ -252,8 +274,7 @@ public class Handler(
         CancellationToken cancellationToken)
     {
         var updatedInfo = state.Steps[step].UpdateStatus(result);
-        var updatedSteps = state.Steps.WithUpdatedStepInfo(step, updatedInfo);
-        var updatedState = state with { Steps = updatedSteps };
+        var updatedState = state with { Steps = state.Steps.WithUpdatedStepInfo(step, updatedInfo) };
 
         var feedbackResult = await discordPublisher.SynchronizedUpdateTrackingMessageAsync(updatedState, cancellationToken);
         if (feedbackResult.IsFailed)

--- a/BotDeScans.App/Features/Publish/Interaction/Handler.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Handler.cs
@@ -12,11 +12,6 @@ namespace BotDeScans.App.Features.Publish.Interaction;
 public class Handler(
     DiscordPublisher discordPublisher)
 {
-    // Caps concurrent conversion steps to avoid file-descriptor exhaustion.
-    // Conversions read from the same source directory; too many parallel opens can hit OS limits.
-    private static readonly SemaphoreSlim ConversionThrottle = new(
-        Environment.ProcessorCount, Environment.ProcessorCount);
-
     public virtual async Task<Result<State>> ExecuteAsync(State state, CancellationToken cancellationToken)
     {
         var managementSteps = state.Steps.ManagementSteps.ToList();
@@ -118,9 +113,11 @@ public class Handler(
         CancellationToken cancellationToken)
         => RunSequentialChainAsync(aggregate, state, chain, RunStepAsync, cancellationToken);
 
-    // Runs conversion steps in parallel, throttled to avoid exceeding OS file-descriptor limits.
-    // Each conversion reads from the same source directory but writes to its own isolated directory,
-    // so there is no write conflict. The semaphore caps concurrency to ProcessorCount.
+    // Runs conversion steps in parallel using Task.WhenAll.
+    // Each step reads from State.OriginContentFolder (read-only, safe for concurrent access on all
+    // major OS/filesystems) and writes to its own isolated directory created by CreateScopedDirectory,
+    // so there are no write conflicts. CPU/I/O throttling is the responsibility of each individual
+    // step implementation (e.g. CompressFilesStep already uses Parallel.ForEachAsync internally).
     private async Task<(Result Result, State State, bool ShouldStop)> RunParallelConversionAsync(
         Result aggregate,
         State state,
@@ -128,21 +125,8 @@ public class Handler(
         CancellationToken cancellationToken)
     {
         var items = conversionSteps.ToList();
-
-        var tasks = items.Select(async item =>
-        {
-            await ConversionThrottle.WaitAsync(cancellationToken);
-            try
-            {
-                return await RunStepAsync((item.Step, item.Info), state, cancellationToken);
-            }
-            finally
-            {
-                ConversionThrottle.Release();
-            }
-        });
-
-        var results = await Task.WhenAll(tasks);
+        var results = await Task.WhenAll(
+            items.Select(item => RunStepAsync((item.Step, item.Info), state, cancellationToken)));
 
         foreach (var (stepResult, item) in results.Zip(items))
         {

--- a/BotDeScans.App/Features/Publish/Interaction/Handler.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Handler.cs
@@ -2,6 +2,7 @@
 using BotDeScans.App.Features.Publish.Interaction.Models;
 using BotDeScans.App.Features.Publish.Interaction.Steps;
 using BotDeScans.App.Features.Publish.Interaction.Steps.Enums;
+using BotDeScans.App.Models.Entities.Enums;
 using FluentResults;
 using Serilog;
 using System.Diagnostics;
@@ -11,22 +12,29 @@ namespace BotDeScans.App.Features.Publish.Interaction;
 public class Handler(
     DiscordPublisher discordPublisher)
 {
+    // Caps concurrent conversion steps to avoid file-descriptor exhaustion.
+    // Conversions read from the same source directory; too many parallel opens can hit OS limits.
+    private static readonly SemaphoreSlim ConversionThrottle = new(
+        Environment.ProcessorCount, Environment.ProcessorCount);
+
     public virtual async Task<Result<State>> ExecuteAsync(State state, CancellationToken cancellationToken)
     {
-        var managementSteps = state.Steps.ManagementSteps;
-        var publishSteps = state.Steps.PublishSteps;
+        var managementSteps = state.Steps.ManagementSteps.ToList();
+        var conversionSteps = state.Steps.ConversionSteps.ToList();
+        var publishSteps = state.Steps.PublishSteps.ToList();
 
         var trackingResult = await discordPublisher.UpdateTrackingMessageAsync(state, cancellationToken);
         if (trackingResult.IsFailed)
             return trackingResult;
 
         var currentState = trackingResult.Value;
+        var currentResult = trackingResult.ToResult();
 
-        var managementExecution = await RunChainAsync(
-            trackingResult.ToResult(),
+        // Phase 1: Setup, Download, Compress — strictly sequential.
+        var managementExecution = await RunSequentialChainAsync(
+            currentResult,
             currentState,
             managementSteps.Select(data => ((IStep)data.Step, data.Info)),
-            RunStepAsync,
             cancellationToken);
         if (managementExecution.ShouldStop)
             return managementExecution.Result.IsFailed
@@ -34,9 +42,28 @@ public class Handler(
                 : Result.Ok(managementExecution.State);
 
         currentState = managementExecution.State;
+        currentResult = managementExecution.Result;
 
-        var validationExecution = await RunChainAsync(
-            managementExecution.Result,
+        // Phase 2: Conversion steps (ZipFiles, PdfFiles, …) — run in parallel with I/O throttle.
+        if (conversionSteps.Count > 0)
+        {
+            var conversionExecution = await RunParallelConversionAsync(
+                currentResult,
+                currentState,
+                conversionSteps,
+                cancellationToken);
+            if (conversionExecution.ShouldStop)
+                return conversionExecution.Result.IsFailed
+                    ? conversionExecution.Result.ToResult<State>()
+                    : Result.Ok(conversionExecution.State);
+
+            currentState = conversionExecution.State;
+            currentResult = conversionExecution.Result;
+        }
+
+        // Phase 3: Validate all publish steps sequentially.
+        var validationExecution = await RunSequentialChainAsync(
+            currentResult,
             currentState,
             publishSteps.Select(data => ((IStep)data.Step, data.Info)),
             RunValidationAsync,
@@ -48,11 +75,11 @@ public class Handler(
 
         currentState = validationExecution.State;
 
-        var publishExecution = await RunChainAsync(
+        // Phase 4: Publish steps — grouped by Dependency, each group in parallel.
+        var publishExecution = await RunParallelDagAsync(
             validationExecution.Result,
             currentState,
-            publishSteps.Select(data => ((IStep)data.Step, data.Info)),
-            RunStepAsync,
+            publishSteps,
             cancellationToken);
 
         return publishExecution.Result.IsFailed
@@ -60,7 +87,8 @@ public class Handler(
             : Result.Ok(publishExecution.State);
     }
 
-    private static async Task<(Result Result, State State, bool ShouldStop)> RunChainAsync(
+    // Runs steps sequentially, used for management and validation phases.
+    private async Task<(Result Result, State State, bool ShouldStop)> RunSequentialChainAsync(
         Result aggregate,
         State state,
         IEnumerable<(IStep Step, StepInfo Info)> chain,
@@ -81,6 +109,119 @@ public class Handler(
 
         return (aggregate, state, false);
     }
+
+    // Overload that defaults to RunStepAsync, used for management execution.
+    private Task<(Result Result, State State, bool ShouldStop)> RunSequentialChainAsync(
+        Result aggregate,
+        State state,
+        IEnumerable<(IStep Step, StepInfo Info)> chain,
+        CancellationToken cancellationToken)
+        => RunSequentialChainAsync(aggregate, state, chain, RunStepAsync, cancellationToken);
+
+    // Runs conversion steps in parallel, throttled to avoid exceeding OS file-descriptor limits.
+    // Each conversion reads from the same source directory but writes to its own isolated directory,
+    // so there is no write conflict. The semaphore caps concurrency to ProcessorCount.
+    private async Task<(Result Result, State State, bool ShouldStop)> RunParallelConversionAsync(
+        Result aggregate,
+        State state,
+        IEnumerable<(IConversionStep Step, StepInfo Info)> conversionSteps,
+        CancellationToken cancellationToken)
+    {
+        var items = conversionSteps.ToList();
+
+        var tasks = items.Select(async item =>
+        {
+            await ConversionThrottle.WaitAsync(cancellationToken);
+            try
+            {
+                return await RunStepAsync((item.Step, item.Info), state, cancellationToken);
+            }
+            finally
+            {
+                ConversionThrottle.Release();
+            }
+        });
+
+        var results = await Task.WhenAll(tasks);
+
+        foreach (var (stepResult, item) in results.Zip(items))
+        {
+            if (stepResult.IsSuccess)
+                state = MergeStates(state, stepResult.Value);
+
+            aggregate = Result.Merge(aggregate, stepResult.ToResult());
+        }
+
+        var hasFatalFailure = results
+            .Zip(items, (r, item) => (Result: r, Step: (IStep)item.Step))
+            .Any(x => x.Result.IsFailed && !x.Step.ContinueOnError);
+
+        return (aggregate, state, hasFatalFailure);
+    }
+
+    // Runs publish steps grouped by Dependency, each group in parallel, groups sequentially.
+    private async Task<(Result Result, State State)> RunParallelDagAsync(
+        Result aggregate,
+        State state,
+        IEnumerable<(IPublishStep Step, StepInfo Info)> publishSteps,
+        CancellationToken cancellationToken)
+    {
+        // Group by dependency: null-dependency steps run after all dependency-based groups
+        var groups = publishSteps
+            .GroupBy(x => x.Step.Dependency)
+            .OrderBy(g => g.Key.HasValue ? 0 : 1)  // dependency groups first, null last
+            .ToList();
+
+        foreach (var group in groups)
+        {
+            var groupItems = group.ToList();
+
+            // Run all steps in this group in parallel
+            var tasks = groupItems.Select(item =>
+                RunStepAsync((item.Step, item.Info), state, cancellationToken));
+
+            var results = await Task.WhenAll(tasks);
+
+            // Merge states from parallel steps (each writes to disjoint properties)
+            foreach (var stepResult in results)
+            {
+                if (stepResult.IsSuccess)
+                    state = MergeStates(state, stepResult.Value);
+
+                aggregate = Result.Merge(aggregate, stepResult.ToResult());
+            }
+
+            // Stop the entire DAG if any non-continuable step failed
+            var hasFatalFailure = results
+                .Zip(groupItems, (r, item) => (Result: r, Step: item.Step))
+                .Any(x => x.Result.IsFailed && !x.Step.ContinueOnError);
+
+            if (hasFatalFailure)
+                return (aggregate, state);
+        }
+
+        return (aggregate, state);
+    }
+
+    // Merges two State instances produced by parallel steps, combining their non-null properties.
+    public static State MergeStates(State @base, State updated) =>
+        @base with
+        {
+            Steps = updated.Steps,
+            TrackingMessage = updated.TrackingMessage,
+            ZipFilePath = updated.ZipFilePath ?? @base.ZipFilePath,
+            PdfFilePath = updated.PdfFilePath ?? @base.PdfFilePath,
+            BoxPdfReaderKey = updated.BoxPdfReaderKey ?? @base.BoxPdfReaderKey,
+            MegaZipLink = updated.MegaZipLink ?? @base.MegaZipLink,
+            MegaPdfLink = updated.MegaPdfLink ?? @base.MegaPdfLink,
+            DriveZipLink = updated.DriveZipLink ?? @base.DriveZipLink,
+            DrivePdfLink = updated.DrivePdfLink ?? @base.DrivePdfLink,
+            BoxZipLink = updated.BoxZipLink ?? @base.BoxZipLink,
+            BoxPdfLink = updated.BoxPdfLink ?? @base.BoxPdfLink,
+            MangaDexLink = updated.MangaDexLink ?? @base.MangaDexLink,
+            SakuraMangasLink = updated.SakuraMangasLink ?? @base.SakuraMangasLink,
+            BloggerLink = updated.BloggerLink ?? @base.BloggerLink,
+        };
 
     private async Task<Result<State>> RunValidationAsync(
         (IStep Step, StepInfo Info) data,
@@ -128,7 +269,7 @@ public class Handler(
         var updatedSteps = state.Steps.WithUpdatedStepInfo(step, updatedInfo);
         var updatedState = state with { Steps = updatedSteps };
 
-        var feedbackResult = await discordPublisher.UpdateTrackingMessageAsync(updatedState, cancellationToken);
+        var feedbackResult = await discordPublisher.SynchronizedUpdateTrackingMessageAsync(updatedState, cancellationToken);
         if (feedbackResult.IsFailed)
             return Result.Merge(result, feedbackResult.ToResult()).ToResult<State>();
 

--- a/BotDeScans.App/Features/Publish/Interaction/Handler.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Handler.cs
@@ -188,10 +188,11 @@ public class Handler(
     }
 
     // Merges two State instances produced by parallel steps, combining their non-null properties.
+    // Steps are merged entry-by-entry so status updates from all parallel steps are preserved.
     public static State MergeStates(State @base, State updated) =>
         @base with
         {
-            Steps = updated.Steps,
+            Steps = @base.Steps?.MergeWith(updated.Steps) ?? updated.Steps,
             TrackingMessage = updated.TrackingMessage,
             ZipFilePath = updated.ZipFilePath ?? @base.ZipFilePath,
             PdfFilePath = updated.PdfFilePath ?? @base.PdfFilePath,

--- a/BotDeScans.App/Features/Publish/Interaction/Models/EnabledSteps.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Models/EnabledSteps.cs
@@ -16,8 +16,12 @@ public class EnabledSteps(Dictionary<IStep, StepInfo> steps) : ReadOnlyDictionar
     }
 
     public IEnumerable<(IManagementStep Step, StepInfo Info)> ManagementSteps =>
-        this.Where(step => step.Key is IManagementStep)
+        this.Where(step => step.Key is IManagementStep and not IConversionStep)
             .Select(step => ((IManagementStep)step.Key, step.Value));
+
+    public IEnumerable<(IConversionStep Step, StepInfo Info)> ConversionSteps =>
+        this.Where(step => step.Key is IConversionStep)
+            .Select(step => ((IConversionStep)step.Key, step.Value));
 
     public IEnumerable<(IPublishStep Step, StepInfo Info)> PublishSteps =>
         this.Where(step => step.Key is IPublishStep)

--- a/BotDeScans.App/Features/Publish/Interaction/Models/EnabledSteps.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Models/EnabledSteps.cs
@@ -15,6 +15,22 @@ public class EnabledSteps(Dictionary<IStep, StepInfo> steps) : ReadOnlyDictionar
         return new EnabledSteps(newDict);
     }
 
+    // Merges two EnabledSteps snapshots produced by parallel steps.
+    // Overrides an entry from `base` only when it is still queued and `other` has a resolved status,
+    // so that a completed status is never overwritten by a pending one from a sibling snapshot.
+    public EnabledSteps MergeWith(EnabledSteps? other)
+    {
+        if (other is null) return this;
+        var queued = new[] { StepStatus.QueuedForExecution, StepStatus.QueuedForValidation };
+        var merged = new Dictionary<IStep, StepInfo>(this);
+        foreach (var (step, updatedInfo) in other)
+            if (merged.TryGetValue(step, out var currentInfo)
+                && queued.Contains(currentInfo.Status)
+                && !queued.Contains(updatedInfo.Status))
+                merged[step] = updatedInfo;
+        return new EnabledSteps(merged);
+    }
+
     public IEnumerable<(IManagementStep Step, StepInfo Info)> ManagementSteps =>
         this.Where(step => step.Key is IManagementStep and not IConversionStep)
             .Select(step => ((IManagementStep)step.Key, step.Value));

--- a/BotDeScans.App/Features/Publish/Interaction/Models/ParallelStepsTracker.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Models/ParallelStepsTracker.cs
@@ -1,0 +1,59 @@
+using BotDeScans.App.Features.Publish.Interaction.Steps;
+using FluentResults;
+
+namespace BotDeScans.App.Features.Publish.Interaction.Models;
+
+/// <summary>
+/// Coordinates state updates and Discord tracking during a parallel step phase.
+/// Each step executes freely (no lock), then calls <see cref="ApplyAndNotifyAsync"/> which
+/// acquires a lock, merges the step's result into the shared current state, and sends
+/// a single Discord update — so users see real-time progress without status regressions.
+/// </summary>
+public class ParallelStepsTracker(
+    State initialState,
+    Func<State, CancellationToken, Task<Result<State>>> sendTrackingUpdate)
+{
+    private readonly SemaphoreSlim _lock = new(1, 1);
+    private State _currentState = initialState;
+    private Result _aggregateTrackingResult = Result.Ok();
+
+    public State CurrentState => _currentState;
+    public Result AggregateTrackingResult => _aggregateTrackingResult;
+
+    /// <summary>
+    /// Called by each parallel step after it finishes executing.
+    /// Merges the step's updated <see cref="StepInfo"/> into the shared state (using the latest
+    /// version, not the snapshot the step started from) and sends the tracking update while holding
+    /// the lock — so the embed always reflects the union of all completed steps so far.
+    /// </summary>
+    public async Task<Result> ApplyAndNotifyAsync(
+        Result stepResult,
+        IStep step,
+        State stepSnapshot,
+        CancellationToken cancellationToken)
+    {
+        await _lock.WaitAsync(cancellationToken);
+        try
+        {
+            // Merge file paths / links from this step's output into the latest shared state.
+            var merged = stepSnapshot.Steps is not null
+                ? Handler.MergeStates(_currentState, stepSnapshot)
+                : _currentState;
+
+            // Apply this step's status onto the freshly merged state.
+            var updatedInfo = merged.Steps[step].UpdateStatus(stepResult);
+            var stateToSend = merged with { Steps = merged.Steps.WithUpdatedStepInfo(step, updatedInfo) };
+
+            var trackingResult = await sendTrackingUpdate(stateToSend, cancellationToken);
+            _aggregateTrackingResult = Result.Merge(_aggregateTrackingResult, trackingResult.ToResult());
+
+            _currentState = trackingResult.IsSuccess ? trackingResult.Value : stateToSend;
+
+            return _aggregateTrackingResult;
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+}

--- a/BotDeScans.App/Features/Publish/Interaction/Models/ParallelStepsTracker.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Models/ParallelStepsTracker.cs
@@ -14,11 +14,9 @@ public class ParallelStepsTracker(
     Func<State, CancellationToken, Task<Result<State>>> sendTrackingUpdate)
 {
     private readonly SemaphoreSlim _lock = new(1, 1);
-    private State _currentState = initialState;
-    private Result _aggregateTrackingResult = Result.Ok();
 
-    public State CurrentState => _currentState;
-    public Result AggregateTrackingResult => _aggregateTrackingResult;
+    public State CurrentState { get; private set; } = initialState;
+    public Result AggregateTrackingResult { get; private set; } = Result.Ok();
 
     /// <summary>
     /// Called by each parallel step after it finishes executing.
@@ -37,19 +35,19 @@ public class ParallelStepsTracker(
         {
             // Merge file paths / links from this step's output into the latest shared state.
             var merged = stepSnapshot.Steps is not null
-                ? Handler.MergeStates(_currentState, stepSnapshot)
-                : _currentState;
+                ? Handler.MergeStates(CurrentState, stepSnapshot)
+                : CurrentState;
 
             // Apply this step's status onto the freshly merged state.
             var updatedInfo = merged.Steps[step].UpdateStatus(stepResult);
             var stateToSend = merged with { Steps = merged.Steps.WithUpdatedStepInfo(step, updatedInfo) };
 
             var trackingResult = await sendTrackingUpdate(stateToSend, cancellationToken);
-            _aggregateTrackingResult = Result.Merge(_aggregateTrackingResult, trackingResult.ToResult());
+            AggregateTrackingResult = Result.Merge(AggregateTrackingResult, trackingResult.ToResult());
 
-            _currentState = trackingResult.IsSuccess ? trackingResult.Value : stateToSend;
+            CurrentState = trackingResult.IsSuccess ? trackingResult.Value : stateToSend;
 
-            return _aggregateTrackingResult;
+            return AggregateTrackingResult;
         }
         finally
         {

--- a/BotDeScans.App/Features/Publish/Interaction/State.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/State.cs
@@ -6,7 +6,6 @@ using BotDeScans.App.Models.Entities;
 using BotDeScans.App.Services.Discord;
 using FluentValidation;
 using Microsoft.Extensions.Configuration;
-using BotDeScans.App.Features.Publish.Interaction.Models;
 
 namespace BotDeScans.App.Features.Publish.Interaction;
 

--- a/BotDeScans.App/Features/Publish/Interaction/Steps/03_ZipFilesStep.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Steps/03_ZipFilesStep.cs
@@ -7,9 +7,9 @@ namespace BotDeScans.App.Features.Publish.Interaction.Steps;
 
 public class ZipFilesStep(
     FileService fileService,
-    FileReleaseService fileReleaseService) : IManagementStep
+    FileReleaseService fileReleaseService) : IConversionStep
 {
-    public StepType Type => StepType.Management;
+    public StepType Type => StepType.Conversion;
     public StepName Name => StepName.ZipFiles;
     public bool IsMandatory => false;
 

--- a/BotDeScans.App/Features/Publish/Interaction/Steps/03_ZipFilesStep.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Steps/03_ZipFilesStep.cs
@@ -13,16 +13,17 @@ public class ZipFilesStep(
     public StepName Name => StepName.ZipFiles;
     public bool IsMandatory => false;
 
-    public Task<Result<State>> ExecuteAsync(State state, CancellationToken cancellationToken)
+    public async Task<Result<State>> ExecuteAsync(State state, CancellationToken cancellationToken)
     {
-        var zipFileResult = fileService.CreateZipFile(
+        var zipFileResult = await fileService.CreateZipFileAsync(
             fileName: state.ChapterInfo.ChapterNumber,
             resourcesDirectory: state.OriginContentFolder,
-            destinationDirectory: fileReleaseService.CreateScopedDirectory());
+            destinationDirectory: fileReleaseService.CreateScopedDirectory(),
+            cancellationToken: cancellationToken);
 
         if (zipFileResult.IsFailed)
-            return Task.FromResult(zipFileResult.ToResult<State>());
+            return zipFileResult.ToResult<State>();
 
-        return Task.FromResult(Result.Ok(state with { ZipFilePath = zipFileResult.Value }));
+        return Result.Ok(state with { ZipFilePath = zipFileResult.Value });
     }
 }

--- a/BotDeScans.App/Features/Publish/Interaction/Steps/04_PdfFilesStep.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Steps/04_PdfFilesStep.cs
@@ -7,9 +7,9 @@ namespace BotDeScans.App.Features.Publish.Interaction.Steps;
 
 public class PdfFilesStep(
     FileService fileService,
-    FileReleaseService fileReleaseService) : IManagementStep
+    FileReleaseService fileReleaseService) : IConversionStep
 {
-    public StepType Type => StepType.Management;
+    public StepType Type => StepType.Conversion;
     public StepName Name => StepName.PdfFiles;
     public bool IsMandatory => false;
 

--- a/BotDeScans.App/Features/Publish/Interaction/Steps/Enums/StepType.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Steps/Enums/StepType.cs
@@ -3,6 +3,7 @@
 public enum StepType
 {
     Management,
+    Conversion,
     Upload,
     Publish
 }

--- a/BotDeScans.App/Features/Publish/Interaction/Steps/IStep.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Steps/IStep.cs
@@ -17,6 +17,12 @@ public interface IManagementStep : IStep
     bool IsMandatory { get; }
 }
 
+// Marks a management step that transforms already-downloaded files (e.g. zip, pdf, epub).
+// These steps read from State.OriginContentFolder and write to an isolated output directory,
+// so multiple conversion steps can run in parallel. A shared I/O throttle in the Handler
+// caps the number of concurrent conversions to avoid file-descriptor exhaustion.
+public interface IConversionStep : IManagementStep { }
+
 public interface IPublishStep : IStep
 {
     StepName? Dependency { get; }

--- a/BotDeScans.App/Features/Publish/Interaction/Steps/IStep.cs
+++ b/BotDeScans.App/Features/Publish/Interaction/Steps/IStep.cs
@@ -18,9 +18,9 @@ public interface IManagementStep : IStep
 }
 
 // Marks a management step that transforms already-downloaded files (e.g. zip, pdf, epub).
-// These steps read from State.OriginContentFolder and write to an isolated output directory,
-// so multiple conversion steps can run in parallel. A shared I/O throttle in the Handler
-// caps the number of concurrent conversions to avoid file-descriptor exhaustion.
+// These steps read from State.OriginContentFolder and write to an isolated output directory.
+// Because they do not share output locations, they are suitable for independent execution;
+// concurrency limits, if any, are determined by the caller/handler implementation.
 public interface IConversionStep : IManagementStep { }
 
 public interface IPublishStep : IStep

--- a/BotDeScans.App/Program.cs
+++ b/BotDeScans.App/Program.cs
@@ -51,10 +51,10 @@ public class Program
             .UseConsoleLifetime()
             .Build();
 
-        Result.Setup(cfg => 
+        Result.Setup(cfg =>
         {
             cfg.Logger = new ResultLogger(Log.Logger);
-            cfg.ExceptionalErrorFactory = (message, ex) => 
+            cfg.ExceptionalErrorFactory = (message, ex) =>
             {
                 var error = new Error(message).CausedBy(ex);
                 var errorResult = new Result().WithError(error);

--- a/BotDeScans.App/Services/FileReleaseService.cs
+++ b/BotDeScans.App/Services/FileReleaseService.cs
@@ -1,4 +1,6 @@
-﻿namespace BotDeScans.App.Services;
+﻿using System.Collections.Concurrent;
+
+namespace BotDeScans.App.Services;
 
 /// <summary>
 /// Manage release files and directories
@@ -7,7 +9,7 @@ public class FileReleaseService : IDisposable
 {
     public static readonly IEnumerable<string> ValidReleaseImageExtensions = ["jpg", "jpeg", "png"];
     private readonly string scopedDirectoryBaseName = Guid.NewGuid().ToString();
-    private readonly List<string> scopedDirectories = [];
+    private readonly ConcurrentBag<string> scopedDirectories = [];
 
     // todo: podemos pensar sobre termos capas dinâmicas. Exemplo: Facebook usar capa-facebook, enquanto o blogger usar capa-blogger;
     // definirmos um nome de capa genérico, caso não ache... e uma configuração de obrigar/não obrigar nomes específicos,
@@ -62,7 +64,7 @@ public class FileReleaseService : IDisposable
         foreach (var scopedDirectory in scopedDirectories)
             Directory.Delete(scopedDirectory, true);
 
-        if (scopedDirectories.Count > 0)
+        if (scopedDirectories.IsEmpty is false)
         {
             var scopedDirectoryBasePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "scoped", scopedDirectoryBaseName);
             Directory.Delete(scopedDirectoryBasePath, true);

--- a/BotDeScans.App/Services/FileService.cs
+++ b/BotDeScans.App/Services/FileService.cs
@@ -24,12 +24,11 @@ public class FileService
     public virtual string GetMimeType(string fileName) =>
         MimeTypes[Path.GetExtension(fileName)];
 
-    // Limitação assíncrona: https://github.com/dotnet/runtime/issues/1541
-    // Todo: foi resolvido no .NET 10, verificar quando migrar
-    public virtual Result<string> CreateZipFile(
+    public virtual async Task<Result<string>> CreateZipFileAsync(
         string fileName,
         string resourcesDirectory,
-        string destinationDirectory)
+        string destinationDirectory,
+        CancellationToken cancellationToken)
     {
         if (resourcesDirectory.Equals(destinationDirectory, StringComparison.InvariantCultureIgnoreCase))
             return Result.Fail("Source and destination directories should not be the same.");
@@ -44,12 +43,12 @@ public class FileService
         var pagesQuantity = (int)Math.Floor(Math.Log10(pages.Length) + 1);
         var filePath = Path.Combine(destinationDirectory, $"{fileName}.zip");
 
-        using var newFile = ZipFile.Open(filePath, ZipArchiveMode.Create);
+        await using var newFile = await ZipFile.OpenAsync(filePath, ZipArchiveMode.Create, cancellationToken);
         for (var i = 0; i < pages.Length; i++)
         {
             var pageNumber = (i + 1).ToString($"D{pagesQuantity}");
             var entryName = $"{pageNumber}{Path.GetExtension(pages[i])}";
-            newFile.CreateEntryFromFile(pages[i], entryName, CompressionLevel.SmallestSize);
+            await newFile.CreateEntryFromFileAsync(pages[i], entryName, CompressionLevel.SmallestSize, cancellationToken);
         }
 
         return filePath;

--- a/BotDeScans.App/Services/GoogleBloggerService.cs
+++ b/BotDeScans.App/Services/GoogleBloggerService.cs
@@ -1,5 +1,4 @@
 ﻿using BotDeScans.App.Extensions;
-using BotDeScans.App.Features.Publish.Interaction;
 using BotDeScans.App.Services.Wrappers;
 using FluentResults;
 using Google.Apis.Blogger.v3;

--- a/BotDeScans.UnitTests/BotDeScans.UnitTests.csproj
+++ b/BotDeScans.UnitTests/BotDeScans.UnitTests.csproj
@@ -14,14 +14,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="9.0.0" />
+    <PackageReference Include="Autofac" Version="9.1.0" />
     <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.18.1" />
     <PackageReference Include="Bogus" Version="35.6.5" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -32,10 +32,10 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
     <PackageReference Include="FluentResults.Extensions.FluentAssertions" Version="2.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Verify" Version="31.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Verify" Version="31.16.3" />
     <PackageReference Include="Verify.FakeItEasy" Version="2.1.0" />
-    <PackageReference Include="Verify.XunitV3" Version="31.9.4" />
+    <PackageReference Include="Verify.XunitV3" Version="31.16.3" />
     <PackageReference Include="xunit.analyzers" Version="1.27.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/HandlerTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/HandlerTests.cs
@@ -506,18 +506,47 @@ public class HandlerTests : UnitTest
         }
 
         [Fact]
-        public async Task GivenConversionStepWithContinueOnErrorShouldContinueToPublishPhase()
+        public async Task GivenConversionStepWithContinueOnErrorShouldStillRunSiblingConversionStep()
         {
             A.CallTo(() => conversionStep1.ExecuteAsync(A<State>.Ignored, cancellationToken))
                 .Returns(Result.Fail<State>("conversion error"));
             A.CallTo(() => conversionStep1.ContinueOnError).Returns(true);
 
-            var result = await handler.ExecuteAsync(conversionTestState, cancellationToken);
+            await handler.ExecuteAsync(conversionTestState, cancellationToken);
 
-            result.Should().BeFailure();
-            // conversionStep2 still ran (parallel in same group)
+            // conversionStep2 still ran in parallel despite conversionStep1 failing
             A.CallTo(() => conversionStep2.ExecuteAsync(A<State>.Ignored, cancellationToken))
                 .MustHaveHappenedOnceExactly();
+        }
+
+        [Fact]
+        public async Task GivenConversionStepWithContinueOnErrorShouldContinueToPublishPhase()
+        {
+            var publishStep = A.Fake<IPublishStep>();
+            var publishStepInfo = A.Fake<StepInfo>();
+            A.CallTo(() => publishStep.Dependency).Returns(null);
+            A.CallTo(() => publishStep.ValidateAsync(A<State>.Ignored, cancellationToken)).Returns(Result.Ok());
+            A.CallTo(() => publishStep.ExecuteAsync(A<State>.Ignored, cancellationToken)).Returns(Result.Ok(state));
+            A.CallTo(() => publishStepInfo.UpdateStatus(A<Result>.Ignored)).Returns(publishStepInfo);
+
+            A.CallTo(() => conversionStep1.ExecuteAsync(A<State>.Ignored, cancellationToken))
+                .Returns(Result.Fail<State>("conversion error"));
+            A.CallTo(() => conversionStep1.ContinueOnError).Returns(true);
+
+            var steps = new EnabledSteps(new Dictionary<IStep, StepInfo>
+            {
+                { managementStep, managementStepInfo },
+                { conversionStep1, conversionStepInfo1 },
+                { conversionStep2, conversionStepInfo2 },
+                { publishStep, publishStepInfo },
+            });
+            var stateWithPublish = state with { Steps = steps };
+
+            var result = await handler.ExecuteAsync(stateWithPublish, cancellationToken);
+
+            result.Should().BeFailure().And.HaveError("conversion error");
+            A.CallTo(() => publishStep.ValidateAsync(A<State>.Ignored, cancellationToken)).MustHaveHappenedOnceExactly();
+            A.CallTo(() => publishStep.ExecuteAsync(A<State>.Ignored, cancellationToken)).MustHaveHappenedOnceExactly();
         }
     }
 

--- a/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/HandlerTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/HandlerTests.cs
@@ -559,7 +559,7 @@ public class HandlerTests : UnitTest
             var updatedState = new State
             {
                 BoxZipLink = "https://box.com/zip",
-                Steps = new EnabledSteps(new Dictionary<IStep, StepInfo>()),
+                Steps = new EnabledSteps([]),
             };
 
             var merged = Handler.MergeStates(baseState, updatedState);
@@ -575,7 +575,7 @@ public class HandlerTests : UnitTest
             var updatedState = new State
             {
                 PdfFilePath = "/tmp/chapter.pdf",
-                Steps = new EnabledSteps(new Dictionary<IStep, StepInfo>()),
+                Steps = new EnabledSteps([]),
             };
 
             var merged = Handler.MergeStates(baseState, updatedState);
@@ -591,7 +591,7 @@ public class HandlerTests : UnitTest
             var updatedState = new State
             {
                 MegaZipLink = "https://new.link",
-                Steps = new EnabledSteps(new Dictionary<IStep, StepInfo>()),
+                Steps = new EnabledSteps([]),
             };
 
             var merged = Handler.MergeStates(baseState, updatedState);
@@ -606,7 +606,7 @@ public class HandlerTests : UnitTest
             var updatedState = new State
             {
                 DriveZipLink = null,
-                Steps = new EnabledSteps(new Dictionary<IStep, StepInfo>()),
+                Steps = new EnabledSteps([]),
             };
 
             var merged = Handler.MergeStates(baseState, updatedState);

--- a/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/HandlerTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/HandlerTests.cs
@@ -21,6 +21,11 @@ public class HandlerTests : UnitTest
             .UpdateTrackingMessageAsync(A<State>._, A<CancellationToken>._))
             .ReturnsLazily((State s, CancellationToken _) => Result.Ok(s));
 
+        A.CallTo(() => fixture
+            .FreezeFake<DiscordPublisher>()
+            .SynchronizedUpdateTrackingMessageAsync(A<State>._, A<CancellationToken>._))
+            .ReturnsLazily((State s, CancellationToken _) => Result.Ok(s));
+
         handler = fixture.Create<Handler>();
         state = new State();
     }
@@ -46,6 +51,12 @@ public class HandlerTests : UnitTest
 
             A.CallTo(() => publishStep1.Name).Returns(StepName.UploadZipGoogleDrive);
             A.CallTo(() => publishStep2.Name).Returns(StepName.UploadMangadex);
+
+            // publishStep1 depends on ZipFiles (group 1), publishStep2 has no dependency (group 2).
+            // This ensures the two publish steps are in different DAG groups so cross-group
+            // break-chain behavior can be verified deterministically.
+            A.CallTo(() => publishStep1.Dependency).Returns(StepName.ZipFiles);
+            A.CallTo(() => publishStep2.Dependency).Returns(null);
 
             A.CallTo(() => managementStep1.ExecuteAsync(A<State>.Ignored, cancellationToken)).Returns(Result.Ok(state));
             A.CallTo(() => managementStep2.ExecuteAsync(A<State>.Ignored, cancellationToken)).Returns(Result.Ok(state));
@@ -83,14 +94,21 @@ public class HandlerTests : UnitTest
         }
 
         [Fact]
-        public async Task GivenSuccessfulExecutionShouldCallExpectedQuantityOfUpdateTrackingMessage()
+        public async Task GivenSuccessfulExecutionShouldCallExpectedQuantityOfSynchronizedUpdateTrackingMessage()
         {
             await handler.ExecuteAsync(testState, cancellationToken);
 
+            // 2 management + 2 validation + 2 publish = 6 synchronized calls
+            A.CallTo(() => fixture
+                .FreezeFake<DiscordPublisher>()
+                .SynchronizedUpdateTrackingMessageAsync(A<State>._, cancellationToken))
+                .MustHaveHappened(6, Times.Exactly);
+
+            // 1 initial tracking call (non-synchronized)
             A.CallTo(() => fixture
                 .FreezeFake<DiscordPublisher>()
                 .UpdateTrackingMessageAsync(A<State>._, cancellationToken))
-                .MustHaveHappened(7, Times.Exactly);
+                .MustHaveHappenedOnceExactly();
         }
 
         [Fact]
@@ -129,7 +147,7 @@ public class HandlerTests : UnitTest
             const string ERROR_MESSAGE = "some error message";
             A.CallTo(() => fixture
                 .FreezeFake<DiscordPublisher>()
-                .UpdateTrackingMessageAsync(A<State>._, cancellationToken))
+                .SynchronizedUpdateTrackingMessageAsync(A<State>._, cancellationToken))
                 .Returns(Result.Fail<State>(ERROR_MESSAGE));
 
             var result = await handler.ExecuteAsync(testState, cancellationToken);
@@ -210,6 +228,9 @@ public class HandlerTests : UnitTest
 
             await handler.ExecuteAsync(testState, cancellationToken);
 
+            // Management and validation phases are always sequential.
+            // Publish steps are in separate DAG groups (step1: ZipFiles dep, step2: no dep),
+            // so group 1 completes before group 2 starts, preserving end-to-end order.
             callOrder.Should().Equal(
                 "managementStep1.Execute",
                 "managementStep2.Execute",
@@ -247,6 +268,8 @@ public class HandlerTests : UnitTest
         [Fact]
         public async Task GivenPublishExecutionErrorShouldBreakChainCall()
         {
+            // publishStep1 is in group 1 (Dependency=ZipFiles), publishStep2 is in group 2 (Dependency=null).
+            // A fatal failure in group 1 stops group 2 from running.
             A.CallTo(() => publishStep1.ExecuteAsync(A<State>.Ignored, cancellationToken))
                 .Returns(Result.Fail<State>("publish execution error"));
 
@@ -275,6 +298,8 @@ public class HandlerTests : UnitTest
         [Fact]
         public async Task GivenExceptionInPublishExecutionShouldBreakChainCall()
         {
+            // publishStep1 is in group 1 (Dependency=ZipFiles), publishStep2 is in group 2 (Dependency=null).
+            // An unhandled exception in group 1 stops group 2 from running.
             A.CallTo(() => publishStep1.ExecuteAsync(A<State>.Ignored, cancellationToken))
                 .Throws(new Exception("publish exception"));
 
@@ -322,6 +347,8 @@ public class HandlerTests : UnitTest
         [Fact]
         public async Task GivenPublishExecutionErrorWithContinueOnErrorShouldContinueChainCall()
         {
+            // publishStep1 is in group 1, publishStep2 is in group 2.
+            // When group 1 fails but ContinueOnError=true, the DAG continues to group 2.
             A.CallTo(() => publishStep1.ExecuteAsync(A<State>.Ignored, cancellationToken))
                 .Returns(Result.Fail<State>("publish error"));
 
@@ -332,6 +359,229 @@ public class HandlerTests : UnitTest
             result.Should().BeFailure();
 
             A.CallTo(() => publishStep2.ExecuteAsync(A<State>.Ignored, cancellationToken)).MustHaveHappenedOnceExactly();
+        }
+
+        [Fact]
+        public async Task GivenParallelStepsInSameGroupShouldMergeTheirOutputStates()
+        {
+            // Two publish steps that share the same dependency group run in parallel.
+            // Their individual State outputs (each setting a different link) must be merged.
+            var parallelStep1 = A.Fake<IPublishStep>();
+            var parallelStep2 = A.Fake<IPublishStep>();
+
+            A.CallTo(() => parallelStep1.Name).Returns(StepName.UploadZipMega);
+            A.CallTo(() => parallelStep2.Name).Returns(StepName.UploadZipBox);
+            A.CallTo(() => parallelStep1.Dependency).Returns(StepName.ZipFiles);
+            A.CallTo(() => parallelStep2.Dependency).Returns(StepName.ZipFiles);
+
+            A.CallTo(() => parallelStep1.ValidateAsync(A<State>.Ignored, cancellationToken)).Returns(Result.Ok());
+            A.CallTo(() => parallelStep2.ValidateAsync(A<State>.Ignored, cancellationToken)).Returns(Result.Ok());
+
+            A.CallTo(() => parallelStep1.ExecuteAsync(A<State>.Ignored, cancellationToken))
+                .ReturnsLazily((State s, CancellationToken _) => Result.Ok(s with { MegaZipLink = "https://mega.nz/zip" }));
+            A.CallTo(() => parallelStep2.ExecuteAsync(A<State>.Ignored, cancellationToken))
+                .ReturnsLazily((State s, CancellationToken _) => Result.Ok(s with { BoxZipLink = "https://box.com/zip" }));
+
+            var parallelStepInfo1 = A.Fake<StepInfo>();
+            var parallelStepInfo2 = A.Fake<StepInfo>();
+            A.CallTo(() => parallelStepInfo1.UpdateStatus(A<Result>.Ignored)).Returns(parallelStepInfo1);
+            A.CallTo(() => parallelStepInfo2.UpdateStatus(A<Result>.Ignored)).Returns(parallelStepInfo2);
+
+            var parallelSteps = new EnabledSteps(new Dictionary<IStep, StepInfo>
+            {
+                { managementStep1, managementStepInfo1 },
+                { parallelStep1, parallelStepInfo1 },
+                { parallelStep2, parallelStepInfo2 },
+            });
+            var parallelState = state with { Steps = parallelSteps };
+
+            var result = await handler.ExecuteAsync(parallelState, cancellationToken);
+
+            result.Should().BeSuccess();
+            result.Value.MegaZipLink.Should().Be("https://mega.nz/zip");
+            result.Value.BoxZipLink.Should().Be("https://box.com/zip");
+        }
+    }
+
+    public class ConversionStepsTests : HandlerTests
+    {
+        private readonly IConversionStep conversionStep1;
+        private readonly IConversionStep conversionStep2;
+        private readonly StepInfo conversionStepInfo1;
+        private readonly StepInfo conversionStepInfo2;
+        private readonly IManagementStep managementStep;
+        private readonly StepInfo managementStepInfo;
+        private readonly State conversionTestState;
+
+        public ConversionStepsTests()
+        {
+            managementStep = A.Fake<IManagementStep>();
+            conversionStep1 = A.Fake<IConversionStep>();
+            conversionStep2 = A.Fake<IConversionStep>();
+
+            A.CallTo(() => managementStep.ExecuteAsync(A<State>.Ignored, cancellationToken)).Returns(Result.Ok(state));
+            A.CallTo(() => conversionStep1.ExecuteAsync(A<State>.Ignored, cancellationToken))
+                .ReturnsLazily((State s, CancellationToken _) => Result.Ok(s with { ZipFilePath = "/tmp/chapter.zip" }));
+            A.CallTo(() => conversionStep2.ExecuteAsync(A<State>.Ignored, cancellationToken))
+                .ReturnsLazily((State s, CancellationToken _) => Result.Ok(s with { PdfFilePath = "/tmp/chapter.pdf" }));
+
+            managementStepInfo = A.Fake<StepInfo>();
+            conversionStepInfo1 = A.Fake<StepInfo>();
+            conversionStepInfo2 = A.Fake<StepInfo>();
+
+            A.CallTo(() => managementStepInfo.UpdateStatus(A<Result>.Ignored)).Returns(managementStepInfo);
+            A.CallTo(() => conversionStepInfo1.UpdateStatus(A<Result>.Ignored)).Returns(conversionStepInfo1);
+            A.CallTo(() => conversionStepInfo2.UpdateStatus(A<Result>.Ignored)).Returns(conversionStepInfo2);
+
+            var steps = new EnabledSteps(new Dictionary<IStep, StepInfo>
+            {
+                { managementStep, managementStepInfo },
+                { conversionStep1, conversionStepInfo1 },
+                { conversionStep2, conversionStepInfo2 },
+            });
+
+            conversionTestState = state with { Steps = steps };
+        }
+
+        [Fact]
+        public async Task GivenConversionStepsShouldRunThemAfterManagementPhase()
+        {
+            var callOrder = new List<string>();
+
+            A.CallTo(() => managementStep.ExecuteAsync(A<State>.Ignored, cancellationToken))
+                .Invokes(() => callOrder.Add("management.Execute"))
+                .Returns(Result.Ok(state));
+            A.CallTo(() => conversionStep1.ExecuteAsync(A<State>.Ignored, cancellationToken))
+                .Invokes(() => callOrder.Add("conversion1.Execute"))
+                .ReturnsLazily((State s, CancellationToken _) => Result.Ok(s with { ZipFilePath = "/tmp/chapter.zip" }));
+            A.CallTo(() => conversionStep2.ExecuteAsync(A<State>.Ignored, cancellationToken))
+                .Invokes(() => callOrder.Add("conversion2.Execute"))
+                .ReturnsLazily((State s, CancellationToken _) => Result.Ok(s with { PdfFilePath = "/tmp/chapter.pdf" }));
+
+            await handler.ExecuteAsync(conversionTestState, cancellationToken);
+
+            callOrder[0].Should().Be("management.Execute");
+            callOrder.Should().Contain("conversion1.Execute");
+            callOrder.Should().Contain("conversion2.Execute");
+        }
+
+        [Fact]
+        public async Task GivenConversionStepsShouldMergeTheirOutputFilePathsIntoState()
+        {
+            var result = await handler.ExecuteAsync(conversionTestState, cancellationToken);
+
+            result.Should().BeSuccess();
+            result.Value.ZipFilePath.Should().Be("/tmp/chapter.zip");
+            result.Value.PdfFilePath.Should().Be("/tmp/chapter.pdf");
+        }
+
+        [Fact]
+        public async Task GivenConversionStepErrorShouldStopBeforePublishPhase()
+        {
+            var publishStep = A.Fake<IPublishStep>();
+            A.CallTo(() => publishStep.Dependency).Returns(null);
+            A.CallTo(() => publishStep.ValidateAsync(A<State>.Ignored, cancellationToken)).Returns(Result.Ok());
+            A.CallTo(() => publishStep.ExecuteAsync(A<State>.Ignored, cancellationToken)).Returns(Result.Ok(state));
+
+            var publishStepInfo = A.Fake<StepInfo>();
+            A.CallTo(() => publishStepInfo.UpdateStatus(A<Result>.Ignored)).Returns(publishStepInfo);
+
+            A.CallTo(() => conversionStep1.ExecuteAsync(A<State>.Ignored, cancellationToken))
+                .Returns(Result.Fail<State>("conversion error"));
+
+            var steps = new EnabledSteps(new Dictionary<IStep, StepInfo>
+            {
+                { managementStep, managementStepInfo },
+                { conversionStep1, conversionStepInfo1 },
+                { publishStep, publishStepInfo },
+            });
+            var stateWithPublish = state with { Steps = steps };
+
+            var result = await handler.ExecuteAsync(stateWithPublish, cancellationToken);
+
+            result.Should().BeFailure().And.HaveError("conversion error");
+            A.CallTo(() => publishStep.ValidateAsync(A<State>.Ignored, cancellationToken)).MustNotHaveHappened();
+            A.CallTo(() => publishStep.ExecuteAsync(A<State>.Ignored, cancellationToken)).MustNotHaveHappened();
+        }
+
+        [Fact]
+        public async Task GivenConversionStepWithContinueOnErrorShouldContinueToPublishPhase()
+        {
+            A.CallTo(() => conversionStep1.ExecuteAsync(A<State>.Ignored, cancellationToken))
+                .Returns(Result.Fail<State>("conversion error"));
+            A.CallTo(() => conversionStep1.ContinueOnError).Returns(true);
+
+            var result = await handler.ExecuteAsync(conversionTestState, cancellationToken);
+
+            result.Should().BeFailure();
+            // conversionStep2 still ran (parallel in same group)
+            A.CallTo(() => conversionStep2.ExecuteAsync(A<State>.Ignored, cancellationToken))
+                .MustHaveHappenedOnceExactly();
+        }
+    }
+
+    public class MergeStatesTests : HandlerTests
+    {
+        [Fact]
+        public void GivenParallelResultsShouldMergeNonNullLinkProperties()
+        {
+            var baseState = new State { MegaZipLink = "https://mega.nz/zip" };
+            var updatedState = new State
+            {
+                BoxZipLink = "https://box.com/zip",
+                Steps = new EnabledSteps(new Dictionary<IStep, StepInfo>()),
+            };
+
+            var merged = Handler.MergeStates(baseState, updatedState);
+
+            merged.MegaZipLink.Should().Be("https://mega.nz/zip");
+            merged.BoxZipLink.Should().Be("https://box.com/zip");
+        }
+
+        [Fact]
+        public void GivenParallelConversionResultsShouldMergeFilePaths()
+        {
+            var baseState = new State { ZipFilePath = "/tmp/chapter.zip" };
+            var updatedState = new State
+            {
+                PdfFilePath = "/tmp/chapter.pdf",
+                Steps = new EnabledSteps(new Dictionary<IStep, StepInfo>()),
+            };
+
+            var merged = Handler.MergeStates(baseState, updatedState);
+
+            merged.ZipFilePath.Should().Be("/tmp/chapter.zip");
+            merged.PdfFilePath.Should().Be("/tmp/chapter.pdf");
+        }
+
+        [Fact]
+        public void GivenUpdatedLinkShouldOverrideBaseLink()
+        {
+            var baseState = new State { MegaZipLink = "https://old.link" };
+            var updatedState = new State
+            {
+                MegaZipLink = "https://new.link",
+                Steps = new EnabledSteps(new Dictionary<IStep, StepInfo>()),
+            };
+
+            var merged = Handler.MergeStates(baseState, updatedState);
+
+            merged.MegaZipLink.Should().Be("https://new.link");
+        }
+
+        [Fact]
+        public void GivenNullUpdatedLinkShouldPreserveBaseLink()
+        {
+            var baseState = new State { DriveZipLink = "https://drive.google.com/zip" };
+            var updatedState = new State
+            {
+                DriveZipLink = null,
+                Steps = new EnabledSteps(new Dictionary<IStep, StepInfo>()),
+            };
+
+            var merged = Handler.MergeStates(baseState, updatedState);
+
+            merged.DriveZipLink.Should().Be("https://drive.google.com/zip");
         }
     }
 }

--- a/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/HandlerTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/HandlerTests.cs
@@ -3,6 +3,7 @@ using BotDeScans.App.Features.Publish.Interaction.Models;
 using BotDeScans.App.Features.Publish.Interaction.Steps;
 using BotDeScans.App.Features.Publish.Interaction.Steps.Enums;
 using BotDeScans.App.Models.Entities.Enums;
+using FluentAssertions.Execution;
 using FluentResults;
 
 namespace BotDeScans.UnitTests.Specs.Features.Publish.Interaction;
@@ -582,6 +583,57 @@ public class HandlerTests : UnitTest
             var merged = Handler.MergeStates(baseState, updatedState);
 
             merged.DriveZipLink.Should().Be("https://drive.google.com/zip");
+        }
+
+        [Fact]
+        public void GivenParallelSnapshotsShouldPreserveStepInfoFromBothSnapshots()
+        {
+            var stepA = A.Fake<IConversionStep>();
+            var stepB = A.Fake<IConversionStep>();
+
+            var baseSteps = new EnabledSteps(new Dictionary<IStep, StepInfo>
+            {
+                { stepA, new StepInfo(stepA) { Status = StepStatus.Success } },
+                { stepB, new StepInfo(stepB) { Status = StepStatus.QueuedForExecution } },
+            });
+
+            var updatedSteps = new EnabledSteps(new Dictionary<IStep, StepInfo>
+            {
+                { stepA, new StepInfo(stepA) { Status = StepStatus.QueuedForExecution } },
+                { stepB, new StepInfo(stepB) { Status = StepStatus.Success } },
+            });
+
+            var baseState = new State { Steps = baseSteps };
+            var updatedState = new State { Steps = updatedSteps };
+
+            var merged = Handler.MergeStates(baseState, updatedState);
+
+            using var _ = new AssertionScope();
+            merged.Steps[stepA].Status.Should().Be(StepStatus.Success);
+            merged.Steps[stepB].Status.Should().Be(StepStatus.Success);
+        }
+
+        [Fact]
+        public void GivenUpdatedStepInfoWithDifferentStatusShouldOverrideBaseStepInfo()
+        {
+            var step = A.Fake<IConversionStep>();
+
+            var baseSteps = new EnabledSteps(new Dictionary<IStep, StepInfo>
+            {
+                { step, new StepInfo(step) { Status = StepStatus.QueuedForExecution } },
+            });
+
+            var updatedSteps = new EnabledSteps(new Dictionary<IStep, StepInfo>
+            {
+                { step, new StepInfo(step) { Status = StepStatus.Success } },
+            });
+
+            var baseState = new State { Steps = baseSteps };
+            var updatedState = new State { Steps = updatedSteps };
+
+            var merged = Handler.MergeStates(baseState, updatedState);
+
+            merged.Steps[step].Status.Should().Be(StepStatus.Success);
         }
     }
 }

--- a/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Models/EnabledStepsTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Models/EnabledStepsTests.cs
@@ -13,12 +13,13 @@ public class EnabledStepsTests : UnitTest
     public class ManagementStepsProperty : EnabledStepsTests
     {
         [Fact]
-        public void ShouldReturnOnlyManagementSteps()
+        public void ShouldReturnOnlyManagementStepsExcludingConversionSteps()
         {
             var steps = new List<IStep>
             {
                 A.Fake<IStep>(),
                 A.Fake<IManagementStep>(),
+                A.Fake<IConversionStep>(),
                 A.Fake<IPublishStep>(),
                 A.Fake<IManagementStep>(),
                 A.Fake<IPublishStep>(),
@@ -29,7 +30,30 @@ public class EnabledStepsTests : UnitTest
             using var _ = new AssertionScope();
             enabledSteps.ManagementSteps.Should().HaveCount(2);
             enabledSteps.ManagementSteps.ElementAt(0).Step.Should().Be(steps[1]);
-            enabledSteps.ManagementSteps.ElementAt(1).Step.Should().Be(steps[3]);
+            enabledSteps.ManagementSteps.ElementAt(1).Step.Should().Be(steps[4]);
+        }
+    }
+
+    public class ConversionStepsProperty : EnabledStepsTests
+    {
+        [Fact]
+        public void ShouldReturnOnlyConversionSteps()
+        {
+            var steps = new List<IStep>
+            {
+                A.Fake<IStep>(),
+                A.Fake<IManagementStep>(),
+                A.Fake<IConversionStep>(),
+                A.Fake<IPublishStep>(),
+                A.Fake<IConversionStep>(),
+            };
+
+            var enabledSteps = new EnabledSteps(steps.ToDictionary(x => x, x => new StepInfo(x)));
+
+            using var _ = new AssertionScope();
+            enabledSteps.ConversionSteps.Should().HaveCount(2);
+            enabledSteps.ConversionSteps.ElementAt(0).Step.Should().Be(steps[2]);
+            enabledSteps.ConversionSteps.ElementAt(1).Step.Should().Be(steps[4]);
         }
     }
 

--- a/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Models/EnabledStepsTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Models/EnabledStepsTests.cs
@@ -167,4 +167,52 @@ public class EnabledStepsTests : UnitTest
                 $":clock9: - {StepName.ZipFiles.GetDescription()}");
         }
     }
+
+    public class MergeWithMethod : EnabledStepsTests
+    {
+        [Fact]
+        public void GivenTwoSnapshotsShouldPreserveUpdatedStatusFromOther()
+        {
+            var stepA = A.Fake<IConversionStep>();
+            var stepB = A.Fake<IConversionStep>();
+
+            var baseSteps = new EnabledSteps(new Dictionary<IStep, StepInfo>
+            {
+                { stepA, new StepInfo(stepA) { Status = StepStatus.Success } },
+                { stepB, new StepInfo(stepB) { Status = StepStatus.QueuedForExecution } },
+            });
+
+            var otherSteps = new EnabledSteps(new Dictionary<IStep, StepInfo>
+            {
+                { stepA, new StepInfo(stepA) { Status = StepStatus.QueuedForExecution } },
+                { stepB, new StepInfo(stepB) { Status = StepStatus.Success } },
+            });
+
+            var merged = baseSteps.MergeWith(otherSteps);
+
+            using var _ = new AssertionScope();
+            merged[stepA].Status.Should().Be(StepStatus.Success);
+            merged[stepB].Status.Should().Be(StepStatus.Success);
+        }
+
+        [Fact]
+        public void GivenSameStatusInBothSnapshotsShouldKeepBaseStepInfo()
+        {
+            var step = A.Fake<IConversionStep>();
+
+            var baseSteps = new EnabledSteps(new Dictionary<IStep, StepInfo>
+            {
+                { step, new StepInfo(step) { Status = StepStatus.Success } },
+            });
+
+            var otherSteps = new EnabledSteps(new Dictionary<IStep, StepInfo>
+            {
+                { step, new StepInfo(step) { Status = StepStatus.Success } },
+            });
+
+            var merged = baseSteps.MergeWith(otherSteps);
+
+            merged[step].Status.Should().Be(StepStatus.Success);
+        }
+    }
 }

--- a/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Models/ParallelStepsTrackerTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Models/ParallelStepsTrackerTests.cs
@@ -1,7 +1,6 @@
 using BotDeScans.App.Features.Publish.Interaction;
 using BotDeScans.App.Features.Publish.Interaction.Models;
 using BotDeScans.App.Features.Publish.Interaction.Steps;
-using BotDeScans.App.Models.Entities.Enums;
 using FluentAssertions.Execution;
 using FluentResults;
 
@@ -61,8 +60,8 @@ public class ParallelStepsTrackerTests : UnitTest
         [Fact]
         public async Task GivenTwoSequentialCallsShouldAccumulateStateWithoutRegressingPriorStep()
         {
-            Task<Result<State>> TrackingCallback(State s, CancellationToken _) =>
-                Task.FromResult(Result.Ok(s));
+            static Task<Result<State>> TrackingCallback(State s, CancellationToken _) =>
+                   Task.FromResult(Result.Ok(s));
 
             var tracker = new ParallelStepsTracker(initialState, TrackingCallback);
 
@@ -105,8 +104,8 @@ public class ParallelStepsTrackerTests : UnitTest
         [Fact]
         public async Task GivenTrackingCallbackFailureShouldAggregateError()
         {
-            Task<Result<State>> TrackingCallback(State s, CancellationToken _) =>
-                Task.FromResult(Result.Fail<State>("discord error"));
+            static Task<Result<State>> TrackingCallback(State s, CancellationToken _) =>
+                   Task.FromResult(Result.Fail<State>("discord error"));
 
             var tracker = new ParallelStepsTracker(initialState, TrackingCallback);
 

--- a/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Models/ParallelStepsTrackerTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Models/ParallelStepsTrackerTests.cs
@@ -94,7 +94,7 @@ public class ParallelStepsTrackerTests : UnitTest
 
             // step1 completes first
             await tracker.ApplyAndNotifyAsync(Result.Ok(), step1, initialState, cancellationToken);
-            // step2 completes second — must not revert step1 back to queued
+            // step2 completes second â€” must not revert step1 back to queued
             await tracker.ApplyAndNotifyAsync(Result.Ok(), step2, initialState, cancellationToken);
 
             using var _ = new AssertionScope();
@@ -116,7 +116,7 @@ public class ParallelStepsTrackerTests : UnitTest
         }
 
         [Fact]
-        public async Task GivenSkippedStepShouldReturnOkWithoutCallingTrackingCallback()
+        public async Task GivenUnchangedSnapshotShouldStillCallTrackingCallback()
         {
             var called = false;
             Task<Result<State>> TrackingCallback(State s, CancellationToken _)
@@ -127,7 +127,7 @@ public class ParallelStepsTrackerTests : UnitTest
 
             var tracker = new ParallelStepsTracker(initialState, TrackingCallback);
 
-            // Simulate skip by passing StepStatus.Skip in StepInfo — tracker tests the ApplyAndNotifyAsync
+            // Simulate skip by passing StepStatus.Skip in StepInfo â€” tracker tests the ApplyAndNotifyAsync
             // path directly, so we simulate a skipped step result as an already-ok result with no snapshot change.
             // The actual skip guard lives in RunStepParallelAsync (Handler), tested via HandlerTests.
             // Here we just verify that a success result with unchanged snapshot still sends a tracking update.

--- a/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Models/ParallelStepsTrackerTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Models/ParallelStepsTrackerTests.cs
@@ -1,0 +1,139 @@
+using BotDeScans.App.Features.Publish.Interaction;
+using BotDeScans.App.Features.Publish.Interaction.Models;
+using BotDeScans.App.Features.Publish.Interaction.Steps;
+using BotDeScans.App.Models.Entities.Enums;
+using FluentAssertions.Execution;
+using FluentResults;
+
+namespace BotDeScans.UnitTests.Specs.Features.Publish.Interaction.Models;
+
+public class ParallelStepsTrackerTests : UnitTest
+{
+    private readonly IStep step1;
+    private readonly IStep step2;
+    private readonly StepInfo stepInfo1;
+    private readonly StepInfo stepInfo2;
+    private readonly State initialState;
+
+    public ParallelStepsTrackerTests()
+    {
+        step1 = A.Fake<IConversionStep>();
+        step2 = A.Fake<IConversionStep>();
+
+        stepInfo1 = A.Fake<StepInfo>();
+        stepInfo2 = A.Fake<StepInfo>();
+
+        A.CallTo(() => stepInfo1.UpdateStatus(A<Result>.Ignored)).Returns(stepInfo1);
+        A.CallTo(() => stepInfo2.UpdateStatus(A<Result>.Ignored)).Returns(stepInfo2);
+
+        initialState = new State
+        {
+            Steps = new EnabledSteps(new Dictionary<IStep, StepInfo>
+            {
+                { step1, stepInfo1 },
+                { step2, stepInfo2 },
+            })
+        };
+    }
+
+    public class ApplyAndNotifyAsync : ParallelStepsTrackerTests
+    {
+        [Fact]
+        public async Task GivenSuccessfulStepShouldUpdateCurrentStateViaTrackingCallback()
+        {
+            var sentStates = new List<State>();
+            Task<Result<State>> TrackingCallback(State s, CancellationToken _)
+            {
+                sentStates.Add(s);
+                return Task.FromResult(Result.Ok(s));
+            }
+
+            var tracker = new ParallelStepsTracker(initialState, TrackingCallback);
+            var snapshot = initialState with { ZipFilePath = "/tmp/chapter.zip" };
+
+            await tracker.ApplyAndNotifyAsync(Result.Ok(), step1, snapshot, cancellationToken);
+
+            using var _ = new AssertionScope();
+            sentStates.Should().HaveCount(1);
+            tracker.CurrentState.ZipFilePath.Should().Be("/tmp/chapter.zip");
+        }
+
+        [Fact]
+        public async Task GivenTwoSequentialCallsShouldAccumulateStateWithoutRegressingPriorStep()
+        {
+            Task<Result<State>> TrackingCallback(State s, CancellationToken _) =>
+                Task.FromResult(Result.Ok(s));
+
+            var tracker = new ParallelStepsTracker(initialState, TrackingCallback);
+
+            var snapshot1 = initialState with { ZipFilePath = "/tmp/chapter.zip" };
+            var snapshot2 = initialState with { PdfFilePath = "/tmp/chapter.pdf" };
+
+            await tracker.ApplyAndNotifyAsync(Result.Ok(), step1, snapshot1, cancellationToken);
+            await tracker.ApplyAndNotifyAsync(Result.Ok(), step2, snapshot2, cancellationToken);
+
+            using var _ = new AssertionScope();
+            tracker.CurrentState.ZipFilePath.Should().Be("/tmp/chapter.zip");
+            tracker.CurrentState.PdfFilePath.Should().Be("/tmp/chapter.pdf");
+        }
+
+        [Fact]
+        public async Task GivenFirstStepAlreadySucceededSecondApplyShouldNotRegressItsStatus()
+        {
+            var updatedInfo1 = A.Fake<StepInfo>();
+            A.CallTo(() => stepInfo1.UpdateStatus(A<Result>.That.Matches(r => r.IsSuccess))).Returns(updatedInfo1);
+
+            var capturedStates = new List<State>();
+            Task<Result<State>> TrackingCallback(State s, CancellationToken _)
+            {
+                capturedStates.Add(s);
+                return Task.FromResult(Result.Ok(s));
+            }
+
+            var tracker = new ParallelStepsTracker(initialState, TrackingCallback);
+
+            // step1 completes first
+            await tracker.ApplyAndNotifyAsync(Result.Ok(), step1, initialState, cancellationToken);
+            // step2 completes second — must not revert step1 back to queued
+            await tracker.ApplyAndNotifyAsync(Result.Ok(), step2, initialState, cancellationToken);
+
+            using var _ = new AssertionScope();
+            // The second Discord embed must still contain step1's resolved StepInfo
+            capturedStates[1].Steps[step1].Should().Be(updatedInfo1);
+        }
+
+        [Fact]
+        public async Task GivenTrackingCallbackFailureShouldAggregateError()
+        {
+            Task<Result<State>> TrackingCallback(State s, CancellationToken _) =>
+                Task.FromResult(Result.Fail<State>("discord error"));
+
+            var tracker = new ParallelStepsTracker(initialState, TrackingCallback);
+
+            await tracker.ApplyAndNotifyAsync(Result.Ok(), step1, initialState, cancellationToken);
+
+            tracker.AggregateTrackingResult.IsFailed.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GivenSkippedStepShouldReturnOkWithoutCallingTrackingCallback()
+        {
+            var called = false;
+            Task<Result<State>> TrackingCallback(State s, CancellationToken _)
+            {
+                called = true;
+                return Task.FromResult(Result.Ok(s));
+            }
+
+            var tracker = new ParallelStepsTracker(initialState, TrackingCallback);
+
+            // Simulate skip by passing StepStatus.Skip in StepInfo — tracker tests the ApplyAndNotifyAsync
+            // path directly, so we simulate a skipped step result as an already-ok result with no snapshot change.
+            // The actual skip guard lives in RunStepParallelAsync (Handler), tested via HandlerTests.
+            // Here we just verify that a success result with unchanged snapshot still sends a tracking update.
+            await tracker.ApplyAndNotifyAsync(Result.Ok(), step1, initialState, cancellationToken);
+
+            called.Should().BeTrue();
+        }
+    }
+}

--- a/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Steps/02_CompressFilesStepTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Steps/02_CompressFilesStepTests.cs
@@ -57,7 +57,7 @@ public class CompressFilesStepTests : UnitTest
             foreach (var filePath in new[] { firstFilePath, secondFilePath })
             {
                 using var image = new Image<Rgba32>(1, 1);
-                image.Mutate(x => x.BackgroundColor(new Rgba32(5, 5, 5)));
+                image.Mutate(x => x.BackgroundColor(Color.FromPixel(new Rgba32(5, 5, 5))));
                 await image.SaveAsync(filePath, cancellationToken);
             }
 

--- a/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Steps/03_ZipFilesStepTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Steps/03_ZipFilesStepTests.cs
@@ -58,10 +58,11 @@ public class ZipFilesStepTests : UnitTest
 
             A.CallTo(() => fixture
                 .FreezeFake<FileService>()
-                .CreateZipFile(
+                .CreateZipFileAsync(
                     state.ChapterInfo.ChapterNumber,
                     state.OriginContentFolder,
-                    scopedDirectory))
+                    scopedDirectory,
+                    cancellationToken))
                 .Returns(Result.Ok(zipPath));
         }
 
@@ -88,7 +89,7 @@ public class ZipFilesStepTests : UnitTest
 
             A.CallTo(() => fixture
                 .FreezeFake<FileService>()
-                .CreateZipFile(A<string>.Ignored, A<string>.Ignored, A<string>.Ignored))
+                .CreateZipFileAsync(A<string>.Ignored, A<string>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored))
                 .Returns(Result.Fail(ERROR_MESSAGE));
 
             var result = await step.ExecuteAsync(state, cancellationToken);

--- a/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Steps/03_ZipFilesStepTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Steps/03_ZipFilesStepTests.cs
@@ -31,7 +31,7 @@ public class ZipFilesStepTests : UnitTest
     {
         [Fact]
         public void ShouldHaveExpectedType() =>
-            step.Type.Should().Be(StepType.Management);
+            step.Type.Should().Be(StepType.Conversion);
 
         [Fact]
         public void ShouldHaveExpectedName() =>

--- a/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Steps/04_PdfFilesStepTests.cs
+++ b/BotDeScans.UnitTests/Specs/Features/Publish/Interaction/Steps/04_PdfFilesStepTests.cs
@@ -31,7 +31,7 @@ public class PdfFilesStepTests : UnitTest
     {
         [Fact]
         public void ShouldHaveExpectedType() =>
-            step.Type.Should().Be(StepType.Management);
+            step.Type.Should().Be(StepType.Conversion);
 
         [Fact]
         public void ShouldHaveExpectedName() =>

--- a/BotDeScans.UnitTests/Specs/Services/FileServiceTests.cs
+++ b/BotDeScans.UnitTests/Specs/Services/FileServiceTests.cs
@@ -111,7 +111,7 @@ public class FileServiceTests : UnitTest
         }
 
         [Fact]
-        public async Task ShouldContainsExpectedFilesInsideZipFile()
+        public async Task ShouldContainExpectedFilesInsideZipFile()
         {
             var result = await service.CreateZipFileAsync(
                 "fileName",

--- a/BotDeScans.UnitTests/Specs/Services/FileServiceTests.cs
+++ b/BotDeScans.UnitTests/Specs/Services/FileServiceTests.cs
@@ -130,7 +130,7 @@ public class FileServiceTests : UnitTest
         }
 
         [Fact]
-        public async Task ShouldContainsExpectedFilesInsideZipFileCreatingPadingLeftZeroes()
+        public async Task ShouldContainsExpectedFilesInsideZipFileCreatingPaddingLeftZeroes()
         {
             File.Create(Path.Combine(resourcesDirectory, "credits.png")).Dispose();
             File.Create(Path.Combine(resourcesDirectory, "01.png")).Dispose();

--- a/BotDeScans.UnitTests/Specs/Services/FileServiceTests.cs
+++ b/BotDeScans.UnitTests/Specs/Services/FileServiceTests.cs
@@ -130,7 +130,7 @@ public class FileServiceTests : UnitTest
         }
 
         [Fact]
-        public async Task ShouldContainsExpectedFilesInsideZipFileCreatingPaddingLeftZeroes()
+        public async Task ShouldContainExpectedFilesInsideZipFileCreatingPaddingLeftZeroes()
         {
             File.Create(Path.Combine(resourcesDirectory, "credits.png")).Dispose();
             File.Create(Path.Combine(resourcesDirectory, "01.png")).Dispose();

--- a/BotDeScans.UnitTests/Specs/Services/FileServiceTests.cs
+++ b/BotDeScans.UnitTests/Specs/Services/FileServiceTests.cs
@@ -56,63 +56,68 @@ public class FileServiceTests : UnitTest
         }
 
         [Fact]
-        public void ShouldCreateZipInExpectedDirectory()
+        public async Task ShouldCreateZipInExpectedDirectory()
         {
-            var result = service.CreateZipFile(
+            var result = await service.CreateZipFileAsync(
                 "fileName",
                 resourcesDirectory,
-                destinationDirectory);
+                destinationDirectory,
+                cancellationToken);
 
             File.Exists(result.Value).Should().BeTrue();
         }
 
         [Fact]
-        public void ShouldReturnZipPath()
+        public async Task ShouldReturnZipPath()
         {
             var expectedPath = Path.Combine(
                 destinationDirectory,
                 "fileName.zip");
 
-            var result = service.CreateZipFile(
+            var result = await service.CreateZipFileAsync(
                 "fileName",
                 resourcesDirectory,
-                destinationDirectory);
+                destinationDirectory,
+                cancellationToken);
 
             result.Should().BeSuccess().And.HaveValue(expectedPath);
         }
 
         [Fact]
-        public void ShouldReturnFailResultIfResourcesDirectoryIsSameThanDestinationDirectory()
+        public async Task ShouldReturnFailResultIfResourcesDirectoryIsSameThanDestinationDirectory()
         {
-            var result = service.CreateZipFile(
+            var result = await service.CreateZipFileAsync(
                 "fileName",
                 resourcesDirectory.ToLower(),
-                resourcesDirectory.ToUpper());
+                resourcesDirectory.ToUpper(),
+                cancellationToken);
 
             result.Should().BeFailure().And.HaveError("Source and destination directories should not be the same.");
         }
 
         [Fact]
-        public void ShouldResutlFailResultIfNoFilesFoundInSourceDirectory()
+        public async Task ShouldReturnFailResultIfNoFilesFoundInSourceDirectory()
         {
             Directory.Delete(resourcesDirectory, true);
             Directory.CreateDirectory(resourcesDirectory);
 
-            var result = service.CreateZipFile(
+            var result = await service.CreateZipFileAsync(
                 "fileName",
                 resourcesDirectory,
-                destinationDirectory);
+                destinationDirectory,
+                cancellationToken);
 
             result.Should().BeFailure().And.HaveError("No files found in the source directory.");
         }
 
         [Fact]
-        public void ShouldContainsExpectedFilesInsideZipFile()
+        public async Task ShouldContainsExpectedFilesInsideZipFile()
         {
-            var result = service.CreateZipFile(
+            var result = await service.CreateZipFileAsync(
                 "fileName",
                 resourcesDirectory,
-                destinationDirectory);
+                destinationDirectory,
+                cancellationToken);
 
             using var zipFile = ZipFile.Open(result.Value, ZipArchiveMode.Read);
 
@@ -125,7 +130,7 @@ public class FileServiceTests : UnitTest
         }
 
         [Fact]
-        public void ShouldContainsExpectedFilesInsideZipFileCreatingPadingLeftZeroes()
+        public async Task ShouldContainsExpectedFilesInsideZipFileCreatingPadingLeftZeroes()
         {
             File.Create(Path.Combine(resourcesDirectory, "credits.png")).Dispose();
             File.Create(Path.Combine(resourcesDirectory, "01.png")).Dispose();
@@ -138,10 +143,11 @@ public class FileServiceTests : UnitTest
             File.Create(Path.Combine(resourcesDirectory, "08.png")).Dispose();
             File.Create(Path.Combine(resourcesDirectory, "09.png")).Dispose();
 
-            var result = service.CreateZipFile(
+            var result = await service.CreateZipFileAsync(
                 "fileName",
                 resourcesDirectory,
-                destinationDirectory);
+                destinationDirectory,
+                cancellationToken);
 
             using var zipFile = ZipFile.Open(result.Value, ZipArchiveMode.Read);
 

--- a/BotDeScans.UnitTests/Specs/Services/GoogleBloggerServiceTests.cs
+++ b/BotDeScans.UnitTests/Specs/Services/GoogleBloggerServiceTests.cs
@@ -1,5 +1,4 @@
-﻿using BotDeScans.App.Features.Publish.Interaction;
-using BotDeScans.App.Services;
+﻿using BotDeScans.App.Services;
 using BotDeScans.App.Services.Wrappers;
 using Google.Apis.Blogger.v3;
 using Google.Apis.Blogger.v3.Data;

--- a/BotDeScans.UnitTests/Specs/Services/ImageServiceTests.cs
+++ b/BotDeScans.UnitTests/Specs/Services/ImageServiceTests.cs
@@ -23,8 +23,8 @@ public class ImageServiceTests : UnitTest, IDisposable
 
     public class IsGrayscale : ImageServiceTests
     {
-        private static readonly Color grey = new Rgba32(5, 5, 5);
-        private static readonly Color notGrey = new Rgba32(5, 5, 6);
+        private static readonly Color grey = Color.FromPixel(new Rgba32(5, 5, 5));
+        private static readonly Color notGrey = Color.FromPixel(new Rgba32(5, 5, 6));
 
         [Fact]
         public async Task GivenGreyImageShouldReturnTrue()
@@ -90,7 +90,7 @@ public class ImageServiceTests : UnitTest, IDisposable
             const string expectedResult = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAMAAAAoyzS7AAAAA1BMVEUFBQWsrP/7AAAACklEQVR4nGNgAAAAAgABSK+kcQAAAABJRU5ErkJggg==";
             using (var image = new Image<Rgba32>(1, 1))
             {
-                image.Mutate(x => x.BackgroundColor(new Rgba32(5, 5, 5)));
+                image.Mutate(x => x.BackgroundColor(Color.FromPixel(new Rgba32(5, 5, 5))));
                 await image.SaveAsync(imagePath, cancellationToken);
             }
 
@@ -108,7 +108,7 @@ public class ImageServiceTests : UnitTest, IDisposable
         {
             using (var image = new Image<Rgba32>(100, 100))
             {
-                image.Mutate(x => x.BackgroundColor(new Rgba32(5, 5, 5)));
+                image.Mutate(x => x.BackgroundColor(Color.FromPixel(new Rgba32(5, 5, 5))));
                 await image.SaveAsync(imagePath, cancellationToken);
             }
 
@@ -126,7 +126,7 @@ public class ImageServiceTests : UnitTest, IDisposable
             var jpgImagePath = Path.ChangeExtension(imagePath, ".jpg");
             using (var image = new Image<Rgba32>(1, 1))
             {
-                image.Mutate(x => x.BackgroundColor(new Rgba32(5, 5, 5)));
+                image.Mutate(x => x.BackgroundColor(Color.FromPixel(new Rgba32(5, 5, 5))));
                 await image.SaveAsync(jpgImagePath, cancellationToken);
             }
 


### PR DESCRIPTION
This pull request refactors the publish workflow to improve concurrency, reliability, and maintainability. The main changes introduce a new `IConversionStep` interface and a new "Conversion" step phase, allowing conversion steps (such as zipping and PDF creation) to run in parallel with proper I/O throttling. The handler logic is restructured into four distinct phases (management, conversion, validation, and publish), with improved error handling and state merging. Additionally, several package dependencies are updated.

**Workflow refactoring and parallelization:**

* Introduced a new `IConversionStep` interface for steps that transform already-downloaded files, and refactored `ZipFilesStep` and `PdfFilesStep` to implement this interface and be executed in parallel during the new "Conversion" phase. [[1]](diffhunk://#diff-0300b53320db3dcff99471a65f66a2ae269d29043450a81f5941296cd499ef98R20-R25) [[2]](diffhunk://#diff-0acadceef61b5f332986622c008876e94eed0c83120c306146a503ed95b5251bL10-R27) [[3]](diffhunk://#diff-7df4879eaed26bd4c668d7c08ffc6d4a11d02fddfc51662e9b968c1413e22cd8L10-R12) [[4]](diffhunk://#diff-5dfe6d0fd42be12f972c6e8c1b302be3134b13a955d83fe8ac9b736c86f9dfecR6)
* Refactored the publish handler (`Handler.cs`) to split execution into four phases: strictly sequential management steps, parallelized conversion steps, sequential validation, and parallelized (by dependency group) publish steps. Added robust state merging and error handling for parallel execution. [[1]](diffhunk://#diff-7f2787ca96a7480cbdbc4339ccdeb31d9206278101a4e2841c76a0471ea12c1bL16-R61) [[2]](diffhunk://#diff-7f2787ca96a7480cbdbc4339ccdeb31d9206278101a4e2841c76a0471ea12c1bL51-R86) [[3]](diffhunk://#diff-7f2787ca96a7480cbdbc4339ccdeb31d9206278101a4e2841c76a0471ea12c1bR108-R209) [[4]](diffhunk://#diff-7f2787ca96a7480cbdbc4339ccdeb31d9206278101a4e2841c76a0471ea12c1bL131-R256) [[5]](diffhunk://#diff-bb4ee6917cf34273d9c1533d1f44c9095921a6ad64134201f323408a6a537769L19-R25)

**Concurrency and reliability improvements:**

* Added a semaphore lock to `DiscordPublisher` to ensure that tracking message updates are performed in a thread-safe manner when called concurrently from parallel steps. [[1]](diffhunk://#diff-ae52b1a025265c1573553893cf919f10dcaa6cc8208c16fc25f8862784c04719R26-R42) [[2]](diffhunk://#diff-7f2787ca96a7480cbdbc4339ccdeb31d9206278101a4e2841c76a0471ea12c1bL131-R256)

**Asynchronous file operations:**

* Refactored `FileService.CreateZipFile` to an asynchronous method (`CreateZipFileAsync`) using async file and zip APIs, improving I/O throughput and enabling safe parallel execution. [[1]](diffhunk://#diff-c721961cf6ae39ca74148d6b49d6bfefbf3fde22abe04dea825f14da85ab03a5L27-R31) [[2]](diffhunk://#diff-c721961cf6ae39ca74148d6b49d6bfefbf3fde22abe04dea825f14da85ab03a5L47-R51) [[3]](diffhunk://#diff-0acadceef61b5f332986622c008876e94eed0c83120c306146a503ed95b5251bL10-R27)

**Dependency updates:**

* Updated several NuGet package versions in both the main and test projects, including `Box.V2.Core`, `Google.Apis.Blogger.v3`, `Microsoft.EntityFrameworkCore.Sqlite`, `Microsoft.Extensions.DependencyInjection`, `System.Drawing.Common`, and test dependencies like `Autofac` and `coverlet`. [[1]](diffhunk://#diff-9644de1fa71ec8635045157fe474a5a178035a33bc13f6f160826463cb867957L28-R33) [[2]](diffhunk://#diff-9644de1fa71ec8635045157fe474a5a178035a33bc13f6f160826463cb867957L43-R49) [[3]](diffhunk://#diff-9644de1fa71ec8635045157fe474a5a178035a33bc13f6f160826463cb867957L60-R60) [[4]](diffhunk://#diff-27d00ccc4eb7608e81b6598d6019e1b0968a070dd39f96ebf4c711198068553bL17-R24)

These changes collectively enhance the performance, safety, and maintainability of the publish workflow, especially for large releases with multiple conversion and publish steps.